### PR TITLE
feat(question): make "Simple Vue" stricter

### DIFF
--- a/questions/6-hard-simple-vue/README.md
+++ b/questions/6-hard-simple-vue/README.md
@@ -6,7 +6,7 @@ By providing a function name `SimpleVue` (similar to `Vue.extend` or `defineComp
 
 In this challenge, we assume that SimpleVue take an Object with `data`, `computed` and `methods` fields as it's only argument,
 
-- `data` is a simple function that returns a object that expose the the context `this`,
+- `data` is a simple function that returns a object that expose the the context `this`, but you can't access data itself or other computer values or methods in `data`.
 
 - `computed` is an Object of functions that take the context as `this`, doing some calculation and returns the result. The computed results should be exposed to the context as the plain return values instead of functions.
 

--- a/questions/6-hard-simple-vue/test-cases.ts
+++ b/questions/6-hard-simple-vue/test-cases.ts
@@ -3,6 +3,11 @@ import { Equal, Expect } from '@type-challenges/utils'
 
 SimpleVue({
   data() {
+    // @ts-expect-error
+    this.firstname
+    // @ts-expect-error
+    this.data()
+
     return {
       firstname: 'Type',
       lastname: 'Challenges',
@@ -15,8 +20,12 @@ SimpleVue({
     },
   },
   methods: {
+    getRandom() {
+      return Math.random()
+    },
     hi() {
       alert(this.fullname.toLowerCase())
+      alert(this.getRandom())
     },
     test() {
       const fullname = this.fullname

--- a/questions/6-hard-simple-vue/test-cases.ts
+++ b/questions/6-hard-simple-vue/test-cases.ts
@@ -6,6 +6,8 @@ SimpleVue({
     // @ts-expect-error
     this.firstname
     // @ts-expect-error
+    this.getRandom()
+    // @ts-expect-error
     this.data()
 
     return {


### PR DESCRIPTION
Added three cases:

```diff
+ // @ts-expect-error
+ this.firstname
+ // @ts-expect-error
+ this.getRandom()
```

This makes sure `data` or methods won't be able to be accessed too early.

```diff
+ // @ts-expect-error
+ this.data()
```

This makes sure `this` on `data` won't be the options itself.

```diff
+ getRandom() {
+   return Math.random()
+ },
...
+ alert(this.getRandom())
```

This makes sure one method can call another method.