### PR TITLE
#7 - Validate if Pick blocks non-key values

### DIFF
--- a/questions/4-easy-pick/test-cases.ts
+++ b/questions/4-easy-pick/test-cases.ts
@@ -3,6 +3,8 @@ import { Equal, Expect } from '@type-challenges/utils'
 type cases = [
   Expect<Equal<Expected1, MyPick<Todo, 'title'>>>,
   Expect<Equal<Expected2, MyPick<Todo, 'title' | 'completed'>>>,
+  // @ts-expect-error
+  MyPick<Todo, 'title' | 'completed' | 'invalid'>,
 ]
 
 interface Todo {


### PR DESCRIPTION
Pick<T, K> only accepts values for K when they are keys of T. The original tests didn't catch if this restriction was not respected.

Feel free to suggest a better approach to this test.