### PR TITLE
fix: ReplaceAll question test case is not complete

### DIFF
--- a/questions/119-medium-replaceall/test-cases.ts
+++ b/questions/119-medium-replaceall/test-cases.ts
@@ -5,5 +5,6 @@ type cases = [
   Expect<Equal<ReplaceAll<'foobarbar', 'bar', 'foo'>, 'foofoofoo'>>,
   Expect<Equal<ReplaceAll<'t y p e s', ' ', ''>, 'types'>>,
   Expect<Equal<ReplaceAll<'foobarbar', '', 'foo'>, 'foobarbar'>>,
+  Expect<Equal<ReplaceAll<'barfoo', 'bar', 'foo'>, 'foofoo'>>,
   Expect<Equal<ReplaceAll<'', '', ''>, ''>>,
 ]


### PR DESCRIPTION
Sorry, my English is not good, but I try to describe the problem.

### Question
`119 - ReplaceAll`

> Implement `ReplaceAll<S, From, To>` which replace the all the substring `From` with `To` in the given string `S`

```ts
/* _____________ Your Code Here _____________ */

type ReplaceAll<S extends string, From extends string, To extends string> =  any

/* _____________ Test Cases _____________ */
import { Equal, Expect } from '@type-challenges/utils'

type cases = [
  Expect<Equal<ReplaceAll<'foobar', 'bar', 'foo'>, 'foofoo'>>,
  Expect<Equal<ReplaceAll<'foobarbar', 'bar', 'foo'>, 'foofoofoo'>>,
  Expect<Equal<ReplaceAll<'t y p e s', ' ', ''>, 'types'>>,
  Expect<Equal<ReplaceAll<'foobarbar', '', 'foo'>, 'foobarbar'>>,
  Expect<Equal<ReplaceAll<'', '', ''>, ''>>,
]
```

The test case does not include use cases starting with `From`.

I think need to add a test case.

```ts
type cases = [
  Expect<Equal<ReplaceAll<'barfoo', 'bar', 'foo'>, 'foofoo'>>
]
```
