### PR TITLE
Fixed typo

### DIFF
--- a/questions/12-medium-chainable-options/README.md
+++ b/questions/12-medium-chainable-options/README.md
@@ -2,7 +2,7 @@
 
 Chainable options are commonly used in Javascript. But when we switch to TypeScript, can you properly type it?
 
-In this challenge, you need to type an object or a class - whatever you like - to provide two function `option(key, value)` and `get()`. In `option`, you can extend the the current config type by the given key and value. We should about to access the final result via `get`.
+In this challenge, you need to type an object or a class - whatever you like - to provide two function `option(key, value)` and `get()`. In `option`, you can extend the current config type by the given key and value. We should about to access the final result via `get`.
 
 For example
 


### PR DESCRIPTION
Fixed typo in `questions/12-medium-chainable-options/README.md`.