### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This project is aimed at helping you better understand how the type system works
 ### Projects
 
 - [Type Gymnastics](https://github.com/g-plane/type-gymnastics)
+- [TypeType Examples](https://github.com/mistlog/typetype-examples)
 
 > TODO
 


### PR DESCRIPTION
Hi, I solved all easy & medium challenges in another way: use [typetype](https://github.com/mistlog/typetype).

* solutions in issues: https://github.com/type-challenges/type-challenges/issues?q=is%3Aissue+mistlog+is%3Aclosed
* solutions in [typetype-examples](https://github.com/mistlog/typetype-examples/tree/main/examples/type-challenges)

I propose that we add [typetype-examples](https://github.com/mistlog/typetype-examples/tree/main/examples/type-challenges) to readme, because it "Provide(s) learning resources or ideas of how to solve challenges".