### PR TITLE
feat: new challenge, replace keys from exist union types

### DIFF
--- a/questions/1024-replace-keys/README.md
+++ b/questions/1024-replace-keys/README.md
@@ -1,0 +1,32 @@
+<!--info-header-start--><h1>replaceKeys <img src="https://img.shields.io/badge/-hard-de3d37" alt="hard"/> <img src="https://img.shields.io/badge/-%23deep-999" alt="#deep"/></h1><blockquote><p>by lullabyjune <a href="https://github.com/lullabyjune" target="_blank">@lullabyjune</a></p></blockquote><p><a href="https://tsch.js.org/956/play" target="_blank"><img src="https://img.shields.io/badge/-Take%20the%20Challenge-3178c6?logo=typescript&logoColor=white" alt="Take the Challenge"/></a> </p><!--info-header-end-->
+
+Implement a type ReplaceKeys, that replace keys in union types, if some type has not this key, just skip replace,
+A type takes three arguments. 
+
+
+For example:
+
+```
+
+type NodeA = {
+  type: 'A'
+  name: string
+}
+
+type NodeB = {
+  type: 'B'
+  id: number
+}
+
+type NodeC = {
+  type: 'C'
+  name: string
+}
+
+type Nodes = NodeA | NodeB | NodeC
+type ReplacedNameNodes = ReplaceKeys<Nodes, 'name', {name: number}> // {type: 'A', name: number} | NodeB | {type: 'C', name: number} // would replace name from string to number
+type ReplacedNotExistKeys = ReplaceKeys<Nodes, 'name', {aa: number}> // {type: 'A', name: never} | NodeB | {type: 'C', name: never} // would replace name to never
+```
+
+
+<!--info-footer-start--><br><a href="../../README.md" target="_blank"><img src="https://img.shields.io/badge/-Back-grey" alt="Back"/></a> <a href="https://tsch.js.org/956/answer" target="_blank"><img src="https://img.shields.io/badge/-Share%20your%20Solutions-teal" alt="Share your Solutions"/></a> <a href="https://tsch.js.org/956/solutions" target="_blank"><img src="https://img.shields.io/badge/-Check%20out%20Solutions-de5a77?logo=awesome-lists&logoColor=white" alt="Check out Solutions"/></a> <!--info-footer-end-->

--- a/questions/1024-replace-keys/info.yml
+++ b/questions/1024-replace-keys/info.yml
@@ -1,0 +1,8 @@
+title: ReplaceKeys
+
+author:
+  name: nightSong
+  email: yxjsysiphus@gmail.com
+  github: lullabyjune
+
+tags: union

--- a/questions/1024-replace-keys/template.ts
+++ b/questions/1024-replace-keys/template.ts
@@ -1,0 +1,1 @@
+type ReplaceKeys<U, T, Y> = any

--- a/questions/1024-replace-keys/test-cases.ts
+++ b/questions/1024-replace-keys/test-cases.ts
@@ -1,0 +1,46 @@
+import { Equal, Expect } from '@type-challenges/utils'
+import { Equal } from '../../utils'
+
+type NodeA = {
+  type: 'A'
+  name: string
+}
+
+type NodeB = {
+  type: 'B'
+  id: number
+}
+
+type NodeC = {
+  type: 'C'
+  name: string
+}
+
+type ReplacedNameNodeA = {
+  type: 'A'
+  name: number
+}
+
+type ReplacedNameNodeC = {
+  type: 'C'
+  name: number
+}
+
+type NoNameNodeA = {
+  type: 'A'
+  name: never
+}
+
+type NoNameNodeC = {
+  type: 'C'
+  name: never
+}
+
+type Nodes = NodeA | NodeB | NodeC
+type NodesReplacedName = ReplacedNameNodeA | NodeB | ReplacedNameNodeC
+type NodesNoName = NoNameNodeA | NoNameNodeC | NodeB
+
+type cases = [
+  Expect<Equal<ReplaceKeys<Nodes, 'name', {name: number}>, NodesReplacedName>>,
+  Expect<Equal<ReplaceKeys<Nodes, 'name', {aa: number}>, NodesNoName>>,
+]


### PR DESCRIPTION
a type ReplaceKeys, that replace keys in union types, if some type has not this key, just skip replace
maybe useful while somebody want to replacing keys exported by third-repo.