### PR TITLE
Update info.yml to set difficulty of 1097-isunion

### DIFF
--- a/questions/1097-null-isunion/info.yml
+++ b/questions/1097-null-isunion/info.yml
@@ -1,4 +1,4 @@
-difficulty: null
+difficulty: medium
 title: IsUnion
 author:
   github: bencor


### PR DESCRIPTION
A '#' character was left in the original new question form and the automation ignored the commented difficulty value.