### PR TITLE
Add test cases for element in between or at start

### DIFF
--- a/questions/898-easy-includes/test-cases.ts
+++ b/questions/898-easy-includes/test-cases.ts
@@ -5,4 +5,6 @@ type cases = [
   Expect<Equal<Includes<['Kars', 'Esidisi','Wamuu', 'Santana'], 'Dio'>, false>>,
   Expect<Equal<Includes<[1, 2, 3, 5, 6, 7], 7>, true>>,
   Expect<Equal<Includes<[1, 2, 3, 5, 6, 7], 4>, false>>,
+  Expect<Equal<Includes<[1, 2, 3], 2>, true>>,
+  Expect<Equal<Includes<[1, 2, 3], 1>, true>>,
 ]


### PR DESCRIPTION
This would invalidate solutions such as:

```typescript
type Includes<T extends readonly any[], U> = T extends [...any[], U] ? true : T extends [U, ...any[]] ? true : false;
```