### PR TITLE
Add another test case with objects

### DIFF
--- a/questions/898-easy-includes/test-cases.ts
+++ b/questions/898-easy-includes/test-cases.ts
@@ -7,4 +7,5 @@ type cases = [
   Expect<Equal<Includes<[1, 2, 3, 5, 6, 7], 4>, false>>,
   Expect<Equal<Includes<[1, 2, 3], 2>, true>>,
   Expect<Equal<Includes<[1, 2, 3], 1>, true>>,
+  Expect<Equal<Includes<[{}], { a: 'A' }>, false>>,
 ]


### PR DESCRIPTION
The reasoning for adding this is because it invalidates the commonly answered:

```ts
type Includes<T extends readonly any[], U> = U extends T[number] ? true : false;
```

Which fails with the test case added.