### PR TITLE
Remove extra imports in `ReplaceKeys`

### DIFF
--- a/questions/1130-medium-replacekeys/test-cases.ts
+++ b/questions/1130-medium-replacekeys/test-cases.ts
@@ -1,4 +1,4 @@
-import { Equal, Expect, ExpectFalse, NotEqual } from '@type-challenges/utils'
+import { Equal, Expect } from '@type-challenges/utils'
 
 type NodeA = {
   type: 'A'


### PR DESCRIPTION
Probably missed this in #1565