### PR TITLE
The lack of the brackets

### DIFF
--- a/questions/459-medium-flatten/README.md
+++ b/questions/459-medium-flatten/README.md
@@ -5,7 +5,7 @@ In this challenge, you would need to write a type that takes an array and emitte
 For example:
 
 ```ts
-type flatten = Flatten<[1, 2, [3, 4], [[[5]]]> // [1, 2, 3, 4, 5]
+type flatten = Flatten<[1, 2, [3, 4], [[[5]]]]> // [1, 2, 3, 4, 5]
 ```
 
 


### PR DESCRIPTION
The generic argument passed by the Flatten type in the example is missing a closing bracket, causing the example to fail