### PR TITLE
Adds complex object in 7-easy-readonly test-case to check for recursiveness

### DIFF
--- a/questions/7-easy-readonly/test-cases.ts
+++ b/questions/7-easy-readonly/test-cases.ts
@@ -8,4 +8,7 @@ interface Todo1 {
   title: string
   description: string
   completed: boolean
+  meta: {
+    author: string
+  }
 }


### PR DESCRIPTION
By default, `Readonly<T>` is **not** recursive. The current test method does not take this into account. Thus, the following (incorrect) answer would be accepted:

```ts
type MyReadonly<T> = {
  readonly [A in keyof T]: MyReadonly<T[A]>
}
```ts

Adding a complex object into the test case would also test if this particular scenario is covered. It should fail if the user's answer is recursive.