### PR TITLE
chore: add test case for 'ReplaceAll'

### DIFF
--- a/questions/119-medium-replaceall/test-cases.ts
+++ b/questions/119-medium-replaceall/test-cases.ts
@@ -7,5 +7,6 @@ type cases = [
   Expect<Equal<ReplaceAll<'foobarbar', '', 'foo'>, 'foobarbar'>>,
   Expect<Equal<ReplaceAll<'barfoo', 'bar', 'foo'>, 'foofoo'>>,
   Expect<Equal<ReplaceAll<'foobarfoobar', 'ob', 'b'>, 'fobarfobar'>>,
+  Expect<Equal<ReplaceAll<'foboorfoboar', 'bo', 'b'>, 'foborfobar'>>,
   Expect<Equal<ReplaceAll<'', '', ''>, ''>>,
 ]


### PR DESCRIPTION
When I look for a better answer to `ReplaceAll`, I found some answers cannot pass extra test case, you can view detail [here](https://github.com/type-challenges/type-challenges/issues/1938#issuecomment-873426597).