### PR TITLE
fix(Merge): update test case

### DIFF
--- a/questions/599-medium-merge/test-cases.ts
+++ b/questions/599-medium-merge/test-cases.ts
@@ -13,6 +13,6 @@ type cases = [
   Expect<Equal<Merge<Foo, Bar>, {
 	a: number;
 	b: number;
-  c: boolean;
+	c: boolean;
   }>>
 ]


### PR DESCRIPTION
I saw some solutions that are wrong but acceptable by the old test case, here is one:
`type Merge<F, S> = {[K in keyof F]: K extends keyof S ? S[K] : F[K]}`
