### PR TITLE
add test case for 898

### DIFF
--- a/questions/898-easy-includes/test-cases.ts
+++ b/questions/898-easy-includes/test-cases.ts
@@ -10,4 +10,5 @@ type cases = [
   Expect<Equal<Includes<[{}], { a: 'A' }>, false>>,
   Expect<Equal<Includes<[boolean, 2, 3, 5, 6, 7], false>, false>>,
   Expect<Equal<Includes<[true, 2, 3, 5, 6, 7], boolean>, false>>,
+  Expect<Equal<Includes<[false, 2, 3, 5, 6, 7], false>, true>>,
 ]


### PR DESCRIPTION
Hi, some solutions based on mapped types like
```
type Mapped<T extends readonly any[], U> = {
  [k in T[number]]: true
}
```
contain an error, because the false or boolean are not included in the keys of the resulting type.

This test case will check it.
