### PR TITLE
fix: add text case for Awaited

### DIFF
--- a/questions/189-easy-awaited/test-cases.ts
+++ b/questions/189-easy-awaited/test-cases.ts
@@ -2,10 +2,12 @@ import { Equal, Expect } from '@type-challenges/utils'
 
 type X = Promise<string>
 type Y = Promise<{ field: number }>
+type Z = Promise<Promise<string | number>>
 
 type cases = [
   Expect<Equal<Awaited<X>, string>>,
   Expect<Equal<Awaited<Y>, { field: number }>>,
+  Expect<Equal<Awaited<Z>, string | number>>,
 ]
 
 // @ts-expect-error


### PR DESCRIPTION
Like the ```Awaited``` type in typescript 4.5 , we need to recursively unwrap Promise