### PR TITLE
fix: add test case for #119 medium replaceall

### DIFF
--- a/questions/119-medium-replaceall/test-cases.ts
+++ b/questions/119-medium-replaceall/test-cases.ts
@@ -2,6 +2,7 @@ import { Equal, Expect } from '@type-challenges/utils'
 
 type cases = [
   Expect<Equal<ReplaceAll<'foobar', 'bar', 'foo'>, 'foofoo'>>,
+  Expect<Equal<ReplaceAll<'foobar', 'bag', 'foo'>, 'foobar'>>,
   Expect<Equal<ReplaceAll<'foobarbar', 'bar', 'foo'>, 'foofoofoo'>>,
   Expect<Equal<ReplaceAll<'t y p e s', ' ', ''>, 'types'>>,
   Expect<Equal<ReplaceAll<'foobarbar', '', 'foo'>, 'foobarbar'>>,


### PR DESCRIPTION
when `From` not exist in the given `S`