### PR TITLE
fix: add test case for 645 medium diff

### DIFF
--- a/questions/645-medium-diff/test-cases.ts
+++ b/questions/645-medium-diff/test-cases.ts
@@ -11,6 +11,6 @@ type Bar = {
 }
 
 type cases = [
-  Expect<Equal<Diff<Foo, Bar>, { gender: number }>>
+  Expect<Equal<Diff<Foo, Bar>, { gender: number }>>,
   Expect<Equal<Diff<Bar,Foo>, { gender: number }>>
 ]

--- a/questions/645-medium-diff/test-cases.ts
+++ b/questions/645-medium-diff/test-cases.ts
@@ -12,4 +12,5 @@ type Bar = {
 
 type cases = [
   Expect<Equal<Diff<Foo, Bar>, { gender: number }>>
+  Expect<Equal<Diff<Bar,Foo>, { gender: number }>>
 ]


### PR DESCRIPTION
`type Diff<O, O1> = { [P in keyof O1 as P extends keyof O ? never : P]: O1[P] }`
can pass `Expect<Equal<Diff<Foo, Bar>, { gender: number }>>`
so we need add  `Expect<Equal<Diff<Bar,Foo>, { gender: number }>>` test case