### PR TITLE
fix: update info.yml for tuple-to-object

### DIFF
--- a/questions/11-easy-tuple-to-object/info.yml
+++ b/questions/11-easy-tuple-to-object/info.yml
@@ -5,4 +5,4 @@ author:
   email: sinoon1218@gamil.com
   github: sinoon
 
-tags: 10, 472, 730, 3188
+related: 10, 472, 730, 3188


### PR DESCRIPTION
The label is related rather than tags. 
The project readme generate not correctly in "By Tags" section.