### PR TITLE
fix: add a test case to 730

### DIFF
--- a/questions/730-hard-union-to-tuple/test-cases.ts
+++ b/questions/730-hard-union-to-tuple/test-cases.ts
@@ -3,6 +3,7 @@ import {Equal, Expect} from '@type-challenges/utils'
 type ExtractValuesOfTuple<T extends any[]> = T[keyof T & number]
 
 type cases = [
+    Expect<Equal<UnionToTuple<'a' | 'b'>['length'], 2>>,
     Expect<Equal<ExtractValuesOfTuple<UnionToTuple<'a' | 'b'>>, 'a' | 'b'>>,
     Expect<Equal<ExtractValuesOfTuple<UnionToTuple<'a'>>, 'a'>>,
     Expect<Equal<ExtractValuesOfTuple<UnionToTuple<any>>, any>>,


### PR DESCRIPTION
I used this case and passed test, however, **it should not expected**, which `UnionToTuple<'a' | 'b'>` is `['a'|'b']`

```ts
type UnionToTuple<T> = [Exclude<T, undefined>]
```

So, I add new case to check Tuple **length**

Now, above case can not pass the test.