### PR TITLE
fix: typo in 5310 test case

### DIFF
--- a/questions/5310-medium-join/test-cases.ts
+++ b/questions/5310-medium-join/test-cases.ts
@@ -3,6 +3,6 @@ import { Equal, Expect, ExpectFalse, NotEqual } from '@type-challenges/utils'
 type cases = [
   Expect<Equal<Join<["a", "p", "p", "l", "e"], "-">, "a-p-p-l-e">>,
   Expect<Equal<Join<["Hello", "World"], " ">, "Hello World">>,
-  Expect<Equal<Join<["2", "2", "2"], 1>, "21212">>，
+  Expect<Equal<Join<["2", "2", "2"], 1>, "21212">>,
   Expect<Equal<Join<["o"], "u">, "o">>
 ]


### PR DESCRIPTION
replace `，` with `,`