### PR TITLE
fix: disable copilot on vscode (spoiler)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
   "i18n-ally.localesPaths": "scripts/locales",
   "i18n-ally.sourceLanguage": "en",
   "i18n-ally.sortKeys": true,
+  "github.copilot.enable": {
+    "typescript": false,
+  },
   "search.exclude": {
     "**/node_modules": true,
     "**/bower_components": true,


### PR DESCRIPTION
I try to play type-challenges but...

<img width="1027" alt="image" src="https://user-images.githubusercontent.com/73962/159032584-7d5b723c-e454-4197-9345-1b94a96cff25.png">

Github Copilot learned many technics and copy and pasted code from here.

So GitHub Copilot is just spoiler on this repo. I think it should be disabled by default.