### PR TITLE
chore: set explicitly removing semicolon in vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,8 @@
     "**/dist": true
   },
   "i18n-ally.keystyle": "flat",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "prettier.semi": false,
+  "typescript.format.semicolons": "remove",
+  "javascript.format.semicolons": "remove"
 }


### PR DESCRIPTION
Override global settings that might force semicolons.