### PR TITLE
Revert #7611 #7624

### DIFF
--- a/questions/3057-easy-push/test-cases.ts
+++ b/questions/3057-easy-push/test-cases.ts
@@ -4,5 +4,4 @@ type cases = [
   Expect<Equal<Push<[], 1>, [1]>>,
   Expect<Equal<Push<[1, 2], '3'>, [1, 2, '3']>>,
   Expect<Equal<Push<['1', 2, '3'], boolean>, ['1', 2, '3', boolean]>>,
-  Expect<Equal<Push<['1', 2, '3'], '3'>, ['1', 2, '3']>>,
 ]

--- a/questions/3060-easy-unshift/test-cases.ts
+++ b/questions/3060-easy-unshift/test-cases.ts
@@ -3,6 +3,5 @@ import { Equal, Expect, ExpectFalse, NotEqual } from '@type-challenges/utils'
 type cases = [
   Expect<Equal<Unshift<[], 1>, [1]>>,
   Expect<Equal<Unshift<[1, 2], 0>, [0, 1, 2,]>>,
-  Expect<Equal<Unshift<['1', 2, '3'], boolean>, [boolean, '1', 2, '3']>>,
-  Expect<Equal<Unshift<['1', 2, '3'], '3'>, ['1', 2, '3']>>,
+  Expect<Equal<Unshift<['1', 2, '3'],boolean>, [boolean, '1', 2, '3']>>,
 ]


### PR DESCRIPTION
In `README.md` of the challenges, they are described as implementation of the type version of Array.push or Array.unshift.
I think elements should be added regardless of whether the elements are already included.

Related comments
https://github.com/type-challenges/type-challenges/pull/7624#issuecomment-1077483824
https://github.com/type-challenges/type-challenges/issues/7727#issuecomment-1080296688