### PR TITLE
Update test-cases.ts

### DIFF
--- a/questions/2946-medium-objectentries/test-cases.ts
+++ b/questions/2946-medium-objectentries/test-cases.ts
@@ -13,4 +13,6 @@ type ModelEntries = ['name', string] | ['age', number] | ['locations', string[] 
 type cases = [
   Expect<Equal<ObjectEntries<Model>,ModelEntries>>,
   Expect<Equal<ObjectEntries<Partial<Model>>,ModelEntries>>,
+  Expect<Equal<ObjectEntries<{ key?: undefined}>, ['key', undefined]>>,
+  Expect<Equal<ObjectEntries<{ key: undefined}>, ['key', undefined]>>
 ]


### PR DESCRIPTION
The result of `<key>?: undefined` and `<key>: undefined` should equal `['<key>', undefined]`