### PR TITLE
enhance: improve test cases in 05153-medium-indexof and 05317-medium-lastindexof

### DIFF
--- a/questions/05153-medium-indexof/test-cases.ts
+++ b/questions/05153-medium-indexof/test-cases.ts
@@ -4,4 +4,6 @@ type cases = [
   Expect<Equal<IndexOf<[1, 2, 3], 2>, 1>>,
   Expect<Equal<IndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>, 2>>,
   Expect<Equal<IndexOf<[0, 0, 0], 2>, -1>>,
+  Expect<Equal<IndexOf<[string, 1, number, 'a'], number>, 2>>,
+  Expect<Equal<IndexOf<[string, 1, number, 'a', any], any>, 4>>
 ]

--- a/questions/05317-medium-lastindexof/test-cases.ts
+++ b/questions/05317-medium-lastindexof/test-cases.ts
@@ -5,4 +5,6 @@ type cases = [
   Expect<Equal<LastIndexOf<[1, 2, 3, 2, 1], 2>, 3>>,
   Expect<Equal<LastIndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>, 7>>,
   Expect<Equal<LastIndexOf<[0, 0, 0], 2>, -1>>,
+  Expect<Equal<LastIndexOf<[string, 2, number, 'a', number, 1], number>, 4>>,
+  Expect<Equal<LastIndexOf<[string, any, 1, number, 'a', any, 1], any>, 5>>
 ]


### PR DESCRIPTION
添加一些类似于[Unique](https://github.com/type-challenges/type-challenges/blob/main/questions/05360-medium-unique/README.md)下的测试用例, 测试例如'1'与string, any等边界情况