### PR TITLE
Update test-cases.ts

### DIFF
--- a/questions/04037-hard-ispalindrome/test-cases.ts
+++ b/questions/04037-hard-ispalindrome/test-cases.ts
@@ -4,6 +4,7 @@ type cases = [
   Expect<Equal<IsPalindrome<'abc'>, false>>,
   Expect<Equal<IsPalindrome<'b'>, true>>,
   Expect<Equal<IsPalindrome<'abca'>, false>>,
+  Expect<Equal<IsPalindrome<'abcba'>, true>>,
   Expect<Equal<IsPalindrome<121>, true>>,
   Expect<Equal<IsPalindrome<19260817>, false>>,
 ]


### PR DESCRIPTION
There are a few posted incorrect solutions that are passing tests because all palindromes are too short, e.g.:
```ts
type IsPalindrome<T extends string | number> = `${T}` extends `${infer L}${infer NT}${infer R}`
? L extends R
  ? IsPalindrome<NT>
  : false
: true;
```