### PR TITLE
add test-cases

### DIFF
--- a/questions/00011-easy-tuple-to-object/test-cases.ts
+++ b/questions/00011-easy-tuple-to-object/test-cases.ts
@@ -1,9 +1,13 @@
 import type { Equal, Expect } from '@type-challenges/utils'
 
 const tuple = ['tesla', 'model 3', 'model X', 'model Y'] as const
+const tupleNumber = [1, 2, 3, 4] as const
+const tupleMix = [1, '2', 3, '4'] as const
 
 type cases = [
   Expect<Equal<TupleToObject<typeof tuple>, { tesla: 'tesla'; 'model 3': 'model 3'; 'model X': 'model X'; 'model Y': 'model Y' }>>,
+  Expect<Equal<TupleToObject<typeof tupleNumber>, { 1: 1; 2: 2; 3: 3; 4: 4 }>>,
+  Expect<Equal<TupleToObject<typeof tupleMix>, { 1: 1; '2': '2'; 3: 3; '4': '4' }>>,
 ]
 
 // @ts-expect-error

--- a/questions/00189-easy-awaited/test-cases.ts
+++ b/questions/00189-easy-awaited/test-cases.ts
@@ -3,11 +3,13 @@ import type { Equal, Expect } from '@type-challenges/utils'
 type X = Promise<string>
 type Y = Promise<{ field: number }>
 type Z = Promise<Promise<string | number>>
+type Z1 = Promise<Promise<Promise<string | boolean>>>
 
 type cases = [
   Expect<Equal<MyAwaited<X>, string>>,
   Expect<Equal<MyAwaited<Y>, { field: number }>>,
   Expect<Equal<MyAwaited<Z>, string | number>>,
+  Expect<Equal<MyAwaited<Z1>, string | boolean>>,
 ]
 
 // @ts-expect-error


### PR DESCRIPTION
Tuples can contain numbers and strings, so I added the test case, the generic type declaration of the existing answer also needs to be modified