### PR TITLE
07258-hard-object-key-paths add testcase

### DIFF
--- a/questions/07258-hard-object-key-paths/test-cases.ts
+++ b/questions/07258-hard-object-key-paths/test-cases.ts
@@ -37,4 +37,8 @@ type cases = [
   Expect<ExpectExtends<ObjectKeyPaths<typeof ref>, 'person.books.[0]'>>,
   Expect<ExpectExtends<ObjectKeyPaths<typeof ref>, 'person.pets.0.type'>>,
   Expect<Equal<ExpectExtends<ObjectKeyPaths<typeof ref>, 'notExist'>, false>>,
+  Expect<Equal<ExpectExtends<ObjectKeyPaths<typeof ref>, 'person.notExist'>, false>>,
+  Expect<Equal<ExpectExtends<ObjectKeyPaths<typeof ref>, 'person.name.'>, false>>,
+  Expect<Equal<ExpectExtends<ObjectKeyPaths<typeof ref>, '.person.name'>, false>>,
+  Expect<Equal<ExpectExtends<ObjectKeyPaths<typeof ref>, 'person.pets.[0]type'>, false>>,
 ]


### PR DESCRIPTION
There are a few posted incorrect solutions that wouldn't pass these tests. Actually, all posted solutions would fall this test
```ts
Expect<Equal<ExpectExtends<ObjectKeyPaths<typeof ref>, 'person.pets.[10].type'>, false>>
```
I'm not sure there is a way to solve the problem to pass it, so I didn't add it to the PR