### PR TITLE
chore(00296-medium-permutation): improve test cases

### DIFF
--- a/questions/00296-medium-permutation/test-cases.ts
+++ b/questions/00296-medium-permutation/test-cases.ts
@@ -4,5 +4,6 @@ type cases = [
   Expect<Equal<Permutation<'A'>, ['A']>>,
   Expect<Equal<Permutation<'A' | 'B' | 'C'>, ['A', 'B', 'C'] | ['A', 'C', 'B'] | ['B', 'A', 'C'] | ['B', 'C', 'A'] | ['C', 'A', 'B'] | ['C', 'B', 'A']>>,
   Expect<Equal<Permutation<'B' | 'A' | 'C'>, ['A', 'B', 'C'] | ['A', 'C', 'B'] | ['B', 'A', 'C'] | ['B', 'C', 'A'] | ['C', 'A', 'B'] | ['C', 'B', 'A']>>,
+  Expect<Equal<Permutation<boolean>, [false, true] | [true, false]>>,
   Expect<Equal<Permutation<never>, []>>,
 ]


### PR DESCRIPTION
Add test case for union types of non-string types.