### PR TITLE
enhance: add a test case to 956-hard-deeppick

### DIFF
--- a/questions/00956-hard-deeppick/test-cases.ts
+++ b/questions/00956-hard-deeppick/test-cases.ts
@@ -22,8 +22,9 @@ type Obj = {
 }
 
 type cases = [
-  Expect<Equal<DeepPick<Obj, ''>, unknown >>,
+  Expect<Equal<DeepPick<Obj, ''>, unknown>>,
   Expect<Equal<DeepPick<Obj, 'a'>, { a: number }>>,
+  Expect<Equal<DeepPick<Obj, 'a' | ''>, { a: number } & unknown>>,
   Expect<Equal<DeepPick<Obj, 'a' | 'obj.e'>, { a: number } & { obj: { e: string } }>>,
   Expect<Equal<DeepPick<Obj, 'a' | 'obj.e' | 'obj.obj2.i'>, { a: number } & { obj: { e: string } } & { obj: { obj2: { i: boolean } } }>>,
 ]


### PR DESCRIPTION
All solutions using the trick of `UnionToIntersection<Union extends Union ? ... : never>` fail in this edge case.

The pattern is `DeepPick<Obj, 'a' | ''>` -> `UnionToIntersection<DeepPick<Obj, 'a'> | DeepPick<Obj, ''>>`

But there is a pitfall:
`UnionToIntersection<object | unknown>` -> `UnionToIntersection<unknown>` -> `unknown`

And in this challenge what we want is: 
`DeepPick<Obj, 'a' | ''>` -> `DeepPick<Obj, 'a'> & DeepPick<Obj, ''>` -> `object & unknown` -> `object`

A proper solution is [this one](https://github.com/type-challenges/type-challenges/issues/3294).