### PR TITLE
test: add ts-expect-error in 3196-flip-arguments

### DIFF
--- a/questions/03196-medium-flip-arguments/test-cases.ts
+++ b/questions/03196-medium-flip-arguments/test-cases.ts
@@ -5,3 +5,14 @@ type cases = [
   Expect<Equal<FlipArguments<(foo: string) => number>, (foo: string) => number>>,
   Expect<Equal<FlipArguments<(arg0: string, arg1: number, arg2: boolean) => void>, (arg0: boolean, arg1: number, arg2: string) => void>>,
 ]
+
+type errors = [
+  // @ts-expect-error
+  FlipArguments<'string'>,
+  // @ts-expect-error
+  FlipArguments<{ key: 'value' }>,
+  // @ts-expect-error
+  FlipArguments<['apple', 'banana', 100, { a: 1 }]>,
+  // @ts-expect-error
+  FlipArguments<null | undefined>,
+]


### PR DESCRIPTION
This question is to examine the function type, so the generic type must be specified as Function, so I added some ts-expect-error.