### PR TITLE
Modify `exclude` test expected response

### DIFF
--- a/questions/00043-easy-exclude/test-cases.ts
+++ b/questions/00043-easy-exclude/test-cases.ts
@@ -1,7 +1,7 @@
 import type { Equal, Expect } from '@type-challenges/utils'
 
 type cases = [
-  Expect<Equal<MyExclude<'a' | 'b' | 'c', 'a'>, Exclude<'a' | 'b' | 'c', 'a'>>>,
-  Expect<Equal<MyExclude<'a' | 'b' | 'c', 'a' | 'b'>, Exclude<'a' | 'b' | 'c', 'a' | 'b'>>>,
-  Expect<Equal<MyExclude<string | number | (() => void), Function>, Exclude<string | number | (() => void), Function>>>,
+  Expect<Equal<MyExclude<'a' | 'b' | 'c', 'a'>, 'b' | 'c'>>,
+  Expect<Equal<MyExclude<'a' | 'b' | 'c', 'a' | 'b'>, 'c'>>,
+  Expect<Equal<MyExclude<string | number | (() => void), Function>, string | number>>,
 ]


### PR DESCRIPTION
If you use the built-in `Exclude`, users can see the answer

![image](https://user-images.githubusercontent.com/29330847/177992120-67c48c33-d90f-466c-8a9d-1ef65630bc23.png)

I modified it to the direct expected response
