### PR TITLE
enhance: add test cases

### DIFF
--- a/questions/00898-easy-includes/test-cases.ts
+++ b/questions/00898-easy-includes/test-cases.ts
@@ -17,4 +17,7 @@ type cases = [
   Expect<Equal<Includes<[1 | 2], 1>, false>>,
   Expect<Equal<Includes<[null], undefined>, false>>,
   Expect<Equal<Includes<[undefined], null>, false>>,
+  Expect<Equal<Includes<[], () => string>, false>>,
+  Expect<Equal<Includes<[], () => IterableIterator<number>>, false>>,
+  Expect<Equal<Includes<[], (separator?: string | undefined) => string>, false>>,
 ]


### PR DESCRIPTION

Found a solution to `Includes`, that covers all current test cases, but is not correct nevertheless.
Adding test cases to cover it.

My solution that covers current test cases
```ts
type MyEqual<X, Y> = (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false

type Includes<T extends readonly any[], U> = (
  keyof  ({
    [
      P in keyof T 
      as P extends 'length'
        ? never 
        : MyEqual<T[P], U> extends true 
          ? P 
          : never
    ]: 1 
  })
) extends never 
  ? false 
  : true
```

It can be modified like this to cover new test cases. Could not think of a way to break the modified version.
```ts
type MyEqual<X, Y> = (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false

type Includes<T extends readonly any[], U> = (
  keyof  ({
    [
      P in keyof T 
      as P extends keyof typeof Array.prototype // <- checking Array.prototype
        ? never 
        : MyEqual<T[P], U> extends true 
          ? P 
          : never
    ]: 1 
  })
) extends never 
  ? false 
  : true
```

A recursive solution to `Includes` also covers new test cases
```ts
type Includes<T extends readonly any[], U> = T extends [infer First, ...infer Rest] 
  ? MyEqual<First, U> extends true 
    ? true 
    : Includes<Rest, U> 
  : false
```

Test cases with explaination
```ts
Includes<[], () => string>                               // covers 'Array#toString' and 'Array#toLocaleString'
Includes<[], () => IterableIterator<number>>             // covers 'Array#keys'
Includes<[], (separator?: string | undefined) => string> // covers 'Array#split'
```
Other Array methods do not seem to cause a problem, not sure why.