### PR TITLE
feat: add test case to 00191-medium-append-argument

### DIFF
--- a/questions/00191-medium-append-argument/test-cases.ts
+++ b/questions/00191-medium-append-argument/test-cases.ts
@@ -9,4 +9,6 @@ type Result2 = (x: undefined) => void
 type cases = [
   Expect<Equal<Case1, Result1>>,
   Expect<Equal<Case2, Result2>>,
+  // @ts-expect-error
+  AppendArgument<unknown, undefined>,
 ]


### PR DESCRIPTION
The first argument must be a function.