### PR TITLE
opt: fix test case for 02070-medium-drop-char

### DIFF
--- a/questions/02070-medium-drop-char/test-cases.ts
+++ b/questions/02070-medium-drop-char/test-cases.ts
@@ -1,8 +1,7 @@
 import type { Equal, Expect } from '@type-challenges/utils'
 
 type cases = [
-  // @ts-expect-error
-  Expect<Equal<DropChar<'butter fly!', ''>, 'butterfly!'>>,
+  Expect<Equal<DropChar<'butter fly!', ''>, 'butter fly!'>>,
   Expect<Equal<DropChar<'butter fly!', ' '>, 'butterfly!'>>,
   Expect<Equal<DropChar<'butter fly!', '!'>, 'butter fly'>>,
   Expect<Equal<DropChar<'    butter fly!        ', ' '>, 'butterfly!'>>,


### PR DESCRIPTION
I think it's better to allow empty string as replace value  than to report error.