### PR TITLE
enhance: add test cases of 00017-hard-currying-1

### DIFF
--- a/questions/00017-hard-currying-1/test-cases.ts
+++ b/questions/00017-hard-currying-1/test-cases.ts
@@ -2,6 +2,7 @@ import type { Equal, Expect } from '@type-challenges/utils'
 
 const curried1 = Currying((a: string, b: number, c: boolean) => true)
 const curried2 = Currying((a: string, b: number, c: boolean, d: boolean, e: boolean, f: string, g: boolean) => true)
+const curried3 = Currying(() => true)
 
 type cases = [
   Expect<Equal<
@@ -10,4 +11,5 @@ type cases = [
   Expect<Equal<
     typeof curried2, (a: string) => (b: number) => (c: boolean) => (d: boolean) => (e: boolean) => (f: string) => (g: boolean) => true
   >>,
+  Expect<Equal<typeof curried3, () => true>>
 ]


### PR DESCRIPTION
I think it would be better if we have a test case that curries a function with empty arguments.