### PR TITLE
enhance:  fix test case of 02757-medium-partialbykeys

### DIFF
--- a/questions/02757-medium-partialbykeys/test-cases.ts
+++ b/questions/02757-medium-partialbykeys/test-cases.ts
@@ -20,7 +20,8 @@ interface UserPartialNameAndAge {
 
 type cases = [
   Expect<Equal<PartialByKeys<User, 'name'>, UserPartialName>>,
-  Expect<Equal<PartialByKeys<User, 'name' | 'unknown'>, UserPartialName>>,
   Expect<Equal<PartialByKeys<User, 'name' | 'age'>, UserPartialNameAndAge>>,
   Expect<Equal<PartialByKeys<User>, Partial<User>>>,
+  // @ts-expect-error
+  Expect<Equal<PartialByKeys<User, 'name' | 'unknown'>, UserPartialName>>,
 ]


### PR DESCRIPTION
Because the description of this problem says that
> `K` specify the set of properties of `T`

So I think it would be better if we validate the `K` generic parameter.