### PR TITLE
fix: update test-cases of 02759-medium-requiredbykeys

### DIFF
--- a/questions/02759-medium-requiredbykeys/test-cases.ts
+++ b/questions/02759-medium-requiredbykeys/test-cases.ts
@@ -19,8 +19,9 @@ interface UserRequiredNameAndAge {
 }
 
 type cases = [
-  Expect<Equal<RequiredByKeys<User, 'name'>, UserRequiredName>>,
-  Expect<Equal<RequiredByKeys<User, 'name' | 'unknown'>, UserRequiredName>>,
-  Expect<Equal<RequiredByKeys<User, 'name' | 'age'>, UserRequiredNameAndAge>>,
+  Expect<Equal<RequiredByKeys<User, "name">, UserRequiredName>>,
+  Expect<Equal<RequiredByKeys<User, "name" | "age">, UserRequiredNameAndAge>>,
   Expect<Equal<RequiredByKeys<User>, Required<User>>>,
+  // @ts-expect-error
+  Expect<Equal<RequiredByKeys<User, "name" | "unknown">, UserRequiredName>>
 ]


### PR DESCRIPTION
This challenge is very similar to 02757-medium-partialbykeys, I think the test-cases should also be consistent
reference：https://github.com/type-challenges/type-challenges/pull/17332