### PR TITLE
feat(03192-medium-reverse)-add-error-cases

### DIFF
--- a/questions/03192-medium-reverse/test-cases.ts
+++ b/questions/03192-medium-reverse/test-cases.ts
@@ -5,3 +5,10 @@ type cases = [
   Expect<Equal<Reverse<['a', 'b']>, ['b', 'a']>>,
   Expect<Equal<Reverse<['a', 'b', 'c']>, ['c', 'b', 'a']>>,
 ]
+
+type errors = [
+  // @ts-expect-error
+  Reverse<'string'>,
+  // @ts-expect-error
+  Reverse<{ key: 'value' }>,
+]


### PR DESCRIPTION
```ts
type errors = [
  // @ts-expect-error
  Reverse<'string'>,
  // @ts-expect-error
  Reverse<{ key: 'value' }>,
]
```