### PR TITLE
Add a test case for unioned object type

### DIFF
--- a/questions/00009-medium-deep-readonly/test-cases.ts
+++ b/questions/00009-medium-deep-readonly/test-cases.ts
@@ -1,10 +1,11 @@
 import type { Equal, Expect } from '@type-challenges/utils'
 
 type cases = [
-  Expect<Equal<DeepReadonly<X>, Expected>>,
+  Expect<Equal<DeepReadonly<X1>, Expected1>>,
+  Expect<Equal<DeepReadonly<X2>, Expected2>>,
 ]
 
-type X = {
+type X1 = {
   a: () => 22
   b: string
   c: {
@@ -27,7 +28,9 @@ type X = {
   }
 }
 
-type Expected = {
+type X2 = { a: string } | { b: number };
+
+type Expected1 = {
   readonly a: () => 22
   readonly b: string
   readonly c: {
@@ -49,3 +52,5 @@ type Expected = {
     }
   }
 }
+
+type Expected2 = { readonly a: string } | { readonly b: number };


### PR DESCRIPTION
There currently is [a popular solution to challenge _00009 - Deep Readonly_](https://github.com/type-challenges/type-challenges/issues/187):

```ts
type DeepReadonly<T> = keyof T extends never
  ? T
  : { readonly [k in keyof T]: DeepReadonly<T[k]> };
```

But [as explained here](https://stackoverflow.com/a/68693367), this answer does not cover cases where a value is a union of object types. On top of that, I also think using `keyof T extends never` to check for the function type is kind of hacky and definitely doesn't clearly express the intent of the code.

This is especially an eyesore when an equally concise and much more expressive solution with better coverage (i.e. using `extends Function ?`) already exists.

This pull request hopes to add a test case to expose the weakness of the popular solution above. It was intentionally made simple without multiple layers since the existing test case already covers layered object types.