### PR TITLE
02257-medium-minusone: Add a test case with an absurdly large number

### DIFF
--- a/questions/02257-medium-minusone/test-cases.ts
+++ b/questions/02257-medium-minusone/test-cases.ts
@@ -7,4 +7,5 @@ type cases = [
   Expect<Equal<MinusOne<100>, 99>>,
   Expect<Equal<MinusOne<1101>, 1100>>,
   Expect<Equal<MinusOne<0>, -1>>,
+  Expect<Equal<MinusOne<9_007_199_254_740_992>, 9_007_199_254_740_991>>,
 ]


### PR DESCRIPTION
Managed to come up with [a solution that works for very large numbers](https://github.com/type-challenges/type-challenges/issues/21030). Thought I could include the largest of them that still worked.

Haha, let me know if you don't want the new test case to be included and I'll close the pull request.