### PR TITLE
Add test cases with absurdly large numbers

### DIFF
--- a/questions/04425-medium-greater-than/test-cases.ts
+++ b/questions/04425-medium-greater-than/test-cases.ts
@@ -8,4 +8,7 @@ type cases = [
   Expect<Equal<GreaterThan<20, 20>, false>>,
   Expect<Equal<GreaterThan<10, 100>, false>>,
   Expect<Equal<GreaterThan<111, 11>, true>>,
+  Expect<Equal<GreaterThan<9_007_199_254_740_991, 9_007_199_254_740_992>, false>>,
+  Expect<Equal<GreaterThan<9_007_199_254_740_992, 9_007_199_254_740_992>, false>>,
+  Expect<Equal<GreaterThan<9_007_199_254_740_992, 9_007_199_254_740_991>, true>>,
 ]


### PR DESCRIPTION
Do we want to spice things up a bit?

Added three test cases comparing `9_007_199_254_740_992` (i.e. 2^53) with itself and `9_007_199_254_740_991`.