### PR TITLE
07544-medium-construct-tuple: Test the maximum allowed tuple size i.e. 9999

### DIFF
--- a/questions/07544-medium-construct-tuple/test-cases.ts
+++ b/questions/07544-medium-construct-tuple/test-cases.ts
@@ -3,7 +3,7 @@ import type { Equal, Expect } from '@type-challenges/utils'
 type cases = [
   Expect<Equal<ConstructTuple<0>, []>>,
   Expect<Equal<ConstructTuple<2>, [unknown, unknown]>>,
-  Expect<Equal<ConstructTuple<999>['length'], 999>>,
+  Expect<Equal<ConstructTuple<9999>['length'], 9999>>,
   // @ts-expect-error
-  Expect<Equal<ConstructTuple<1000>['length'], 1000>>,
+  Expect<Equal<ConstructTuple<10000>['length'], 10000>>,
 ]


### PR DESCRIPTION
Why expect error at length 1000?

It's definitely possible to produce a tuple of size up to 9999. At size 10000 though you do get an error saying the tuple is too large to represent.