### PR TITLE
test: if duplicate key exists and new value is empty in 00151-extreme-query-string-parser 

### DIFF
--- a/questions/00151-extreme-query-string-parser/test-cases.ts
+++ b/questions/00151-extreme-query-string-parser/test-cases.ts
@@ -12,4 +12,6 @@ type cases = [
   Expect<Equal<ParseQueryString<'k1=v1&k2'>, { k1: 'v1'; k2: true }>>,
   Expect<Equal<ParseQueryString<'k1=v1&k1=v1'>, { k1: 'v1' }>>,
   Expect<Equal<ParseQueryString<'k1=v1&k2=v2&k1=v2&k1=v3'>, { k1: ['v1', 'v2', 'v3']; k2: 'v2' }>>,
+  Expect<Equal<ParseQueryString<'k1=v1&k1'>, { k1: ['v1', true] }>>,
+  Expect<Equal<ParseQueryString<'k1&k1=v1'>, { k1: [true, 'v1'] }>>,
 ]


### PR DESCRIPTION
- `Query String Parser` doesn't define how new entries with empty values should be handled if a duplicate key already exists in the parsed object. 
- There are two possible ways to handle this case.
  - 1) merge `true` into tuple value for existing key
  - 2) always override existing value with `true`
- This commit illustrates the first case.

See: 151 - Query String Parser (with explanation, new test cases) #21419 