### PR TITLE
test: fix false negative in 08804-hard-two-sum test cases

### DIFF
--- a/questions/08804-hard-two-sum/test-cases.ts
+++ b/questions/08804-hard-two-sum/test-cases.ts
@@ -12,4 +12,5 @@ type cases = [
   Expect<Equal<TwoSum<[1, 2, 3], 4>, true>>,
   Expect<Equal<TwoSum<[1, 2, 3], 5>, true>>,
   Expect<Equal<TwoSum<[1, 2, 3], 6>, false>>,
+  Expect<Equal<TwoSum<[3, 2, 0], 2>, true>>,
 ]


### PR DESCRIPTION
- Currently, all test cases are written s.t. all input elements are leq to the target number.

- If TwoSum is written to terminate and return false when an input element is greater than the target number, it will pass all existing test cases, resulting in a false negative.

- Example:
```
  T extends [infer E extends number, ...infer Rest extends number[]]
    ? Subtract<U, E> extends never
      ? false
      : (...processes Rest correctly...)
```

- The proposed addition tests TwoSum against a non-empty tuple with a head element that is greater than the target number.

See: 8804 - Two Sum (with explanation, new test case) #21260