### PR TITLE
test: fix false negative in 04518-medium-fill when start, end are both out of bounds and not inverted

### DIFF
--- a/questions/04518-medium-fill/test-cases.ts
+++ b/questions/04518-medium-fill/test-cases.ts
@@ -10,5 +10,6 @@ type cases = [
   Expect<Equal<Fill<[1, 2, 3], true, 0, 1>, [true, 2, 3]>>,
   Expect<Equal<Fill<[1, 2, 3], true, 1, 3>, [1, true, true]>>,
   Expect<Equal<Fill<[1, 2, 3], true, 10, 0>, [1, 2, 3]>>,
+  Expect<Equal<Fill<[1, 2, 3], true, 10, 20>, [1, 2, 3]>>,
   Expect<Equal<Fill<[1, 2, 3], true, 0, 10>, [true, true, true]>>,
 ]


### PR DESCRIPTION
- Currently, solutions that do not handle input s.t. `T["length"] <= Start <= End` by returning `T` can pass all test cases.

- See: #21503
```ts
// Example: `Fill<[1, 2, 3], true, 10, 20>` resolves to `never`, but passes all test cases.
type Fill<
  T extends unknown[],
  N,
  Start extends number = 0,
  End extends number = T['length'],
  MStart extends number = Subtract<T["length"], Start> extends never ? T["length"] : Start,
  MEnd extends number = Subtract<T["length"], End> extends never ? T["length"] : End,
  M extends number|never = Subtract<MEnd, MStart>,
> = 
  Subtract<End, Start> extends never
    ? T
    : [...Pop<T, Subtract<T["length"], Start>>, ...Repeat<M, N>, ...Shift<T, End>]
// Fix: `Fill<[1, 2, 3], true, 10, 20>` correctly resolves to `[1, 2, 3]`
    : [...Pop<T, Subtract<T["length"], MStart>>, ...Repeat<M, N>, ...Shift<T, MEnd>]

```