### PR TITLE
test: 00274-extreme-integers-comparator test inputs of different lengths, large numbers

### DIFF
--- a/questions/00274-extreme-integers-comparator/test-cases.ts
+++ b/questions/00274-extreme-integers-comparator/test-cases.ts
@@ -18,4 +18,11 @@ type cases = [
   Expect<Equal<Comparator<-36, 36>, Comparison.Lower>>,
   Expect<Equal<Comparator<27, 27>, Comparison.Equal>>,
   Expect<Equal<Comparator<-38, -38>, Comparison.Equal>>,
+
+  Expect<Equal<Comparator<1, 100>, Comparison.Lower>>,
+  Expect<Equal<Comparator<100, 1>, Comparison.Greater>>,
+  Expect<Equal<Comparator<-100, 1>, Comparison.Lower>>,
+  Expect<Equal<Comparator<1, -100>, Comparison.Greater>>,
+  Expect<Equal<Comparator<-100, -1>, Comparison.Lower>>,
+  Expect<Equal<Comparator<-1, -100>, Comparison.Greater>>,
 ]

--- a/questions/00274-extreme-integers-comparator/test-cases.ts
+++ b/questions/00274-extreme-integers-comparator/test-cases.ts
@@ -26,6 +26,7 @@ type cases = [
   Expect<Equal<Comparator<-100, -1>, Comparison.Lower>>,
   Expect<Equal<Comparator<-1, -100>, Comparison.Greater>>,
 
+  // Extra tests if you like to challenge yourself!
   Expect<Equal<Comparator<9007199254740992, 9007199254740992>, Comparison.Equal>>,
   Expect<Equal<Comparator<-9007199254740992, -9007199254740992>, Comparison.Equal>>,
   Expect<Equal<Comparator<9007199254740991, 9007199254740992>, Comparison.Lower>>,

--- a/questions/00274-extreme-integers-comparator/test-cases.ts
+++ b/questions/00274-extreme-integers-comparator/test-cases.ts
@@ -25,4 +25,11 @@ type cases = [
   Expect<Equal<Comparator<1, -100>, Comparison.Greater>>,
   Expect<Equal<Comparator<-100, -1>, Comparison.Lower>>,
   Expect<Equal<Comparator<-1, -100>, Comparison.Greater>>,
+
+  Expect<Equal<Comparator<9007199254740992, 9007199254740992>, Comparison.Equal>>,
+  Expect<Equal<Comparator<-9007199254740992, -9007199254740992>, Comparison.Equal>>,
+  Expect<Equal<Comparator<9007199254740991, 9007199254740992>, Comparison.Lower>>,
+  Expect<Equal<Comparator<9007199254740992, 9007199254740991>, Comparison.Greater>>,
+  Expect<Equal<Comparator<-9007199254740992, -9007199254740991>, Comparison.Lower>>,
+  Expect<Equal<Comparator<-9007199254740991, -9007199254740992>, Comparison.Greater>>,
 ]


### PR DESCRIPTION
1. The existing test cases all compare integers of equal lengths. 
2. Large inputs aren't covered. Added test cases for `Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER`.

See: #21601