### PR TITLE
fix: 462 - Curring 2 - add a test cases

### DIFF
--- a/questions/00462-extreme-currying-2/test-cases.ts
+++ b/questions/00462-extreme-currying-2/test-cases.ts
@@ -18,6 +18,11 @@ const curried2Return8 = curried2('123', 123, true, false, true)('123')(false)
 const curried2Return9 = curried2('123', 123, true, false, true, '123')(false)
 const curried2Return10 = curried2('123', 123, true, false, true, '123', false)
 
+// @ts-expect-error
+const curried1ReturnWrong = curried1('123')(123)('wrong arg type')
+// @ts-expect-error
+const curried1ReturnWrong2 = curried1('123')()(123)(true)
+
 type cases = [
   Expect<Equal< typeof curried1Return1, boolean>>,
   Expect<Equal< typeof curried1Return2, boolean>>,


### PR DESCRIPTION
The first test case crashes:
https://github.com/type-challenges/type-challenges/issues/18047 https://github.com/type-challenges/type-challenges/issues/22172 https://github.com/type-challenges/type-challenges/issues/16231 https://github.com/type-challenges/type-challenges/issues/13943 https://github.com/type-challenges/type-challenges/issues/13669 https://github.com/type-challenges/type-challenges/issues/8272 https://github.com/type-challenges/type-challenges/issues/3747 https://github.com/type-challenges/type-challenges/issues/761

The second test case crashes:
https://github.com/type-challenges/type-challenges/issues/15988 https://github.com/type-challenges/type-challenges/issues/6835 https://github.com/type-challenges/type-challenges/issues/5342 https://github.com/type-challenges/type-challenges/issues/774

This doesn't eliminate the possibility of short beautiful solutions. Here are examples that pass the new test cases: https://github.com/type-challenges/type-challenges/issues/11383 https://github.com/type-challenges/type-challenges/issues/5813 https://github.com/type-challenges/type-challenges/issues/4099 https://github.com/type-challenges/type-challenges/issues/3697