### PR TITLE
9286 - FirstUniqueCharIndex - add a test case

### DIFF
--- a/questions/09286-medium-firstuniquecharindex/test-cases.ts
+++ b/questions/09286-medium-firstuniquecharindex/test-cases.ts
@@ -5,4 +5,5 @@ type cases = [
   Expect<Equal<FirstUniqueCharIndex<'loveleetcode'>, 2>>,
   Expect<Equal<FirstUniqueCharIndex<'aabb'>, -1>>,
   Expect<Equal<FirstUniqueCharIndex<''>, -1>>,
+  Expect<Equal<FirstUniqueCharIndex<'aaa'>, -1>>,
 ]


### PR DESCRIPTION
Crashes at least one posted solution: https://github.com/type-challenges/type-challenges/issues/22117 I didn't check others - I assume it can be a popular misslooked edge-case