### PR TITLE
4425 - GreaterThan - add test case

### DIFF
--- a/questions/04425-medium-greater-than/test-cases.ts
+++ b/questions/04425-medium-greater-than/test-cases.ts
@@ -5,7 +5,9 @@ type cases = [
   Expect<Equal<GreaterThan<5, 4>, true>>,
   Expect<Equal<GreaterThan<4, 5>, false>>,
   Expect<Equal<GreaterThan<0, 0>, false>>,
+  Expect<Equal<GreaterThan<10, 9>, true>>,
   Expect<Equal<GreaterThan<20, 20>, false>>,
   Expect<Equal<GreaterThan<10, 100>, false>>,
   Expect<Equal<GreaterThan<111, 11>, true>>,
+  Expect<Equal<GreaterThan<1234567891011, 1234567891010>, true>>,
 ]


### PR DESCRIPTION
This test case with `<10, 9>` is different from the `<111, 11>` in the way that it has arguments of different lengths, AND a lower number has greater digits. The [solution I've recently posted to this problem](https://github.com/type-challenges/type-challenges/issues/21721) appeared to have this bug, and it had been figured out only thanks to @Yueleng

Also, I've added a test case with a big number (within a safe Number range) that I've noted some other solutions are failing on