### PR TITLE
enhance: add more test cases to 13580-hard-replace-union

### DIFF
--- a/questions/13580-hard-replace-union/test-cases.ts
+++ b/questions/13580-hard-replace-union/test-cases.ts
@@ -7,4 +7,10 @@ type cases = [
 
   // Date -> string; Function -> undefined
   Expect<Equal<UnionReplace<Function | Date | object, [[Date, string], [Function, undefined]]>, undefined | string | object>>,
+
+  // Date -> string; object -> undefined
+  Expect<Equal<UnionReplace<Function | Date | object, [[Date, string], [object, undefined]]>, Function | string | undefined>>,
+
+  // () => number -> never
+  Expect<Equal<UnionReplace<(() => 0) | (() => number), [[() => number, never]]>, () => 0>>,
 ]


### PR DESCRIPTION
The main idea of this PR is to complement an edge case, in which there are both a type and its subtype while their union is not the type itself, such as `object | Function` or `(() => 0) | (() => number)`. In such case, we cannot differentiate them simply by `extends` or `Exclude`. The lack of edge case makes this challenge less suitable to be a *hard* one.