### PR TITLE
Endswith update test-cases.ts

### DIFF
--- a/questions/02693-medium-endswith/test-cases.ts
+++ b/questions/02693-medium-endswith/test-cases.ts
@@ -4,4 +4,7 @@ type cases = [
   Expect<Equal<EndsWith<'abc', 'bc'>, true>>,
   Expect<Equal<EndsWith<'abc', 'abc'>, true>>,
   Expect<Equal<EndsWith<'abc', 'd'>, false>>,
+  Expect<Equal<EndsWith<"abc", "ac">, false>>,
+  Expect<Equal<EndsWith<"abc", "">, true>>,
+  Expect<Equal<EndsWith<"abc", " ">, false>>
 ]


### PR DESCRIPTION
```ts
type last<T> = T extends `${infer L}${infer R}` ? (R extends "" ? L : last<R>) : T;
type EndsWith<T extends string, U extends string> = last<T> extends last<U> ? true : false
```

Previous cases cannot be overwritten