### PR TITLE
add difficulty for questions - 00015, 000016, 00017 and 00018, preventing undefined filename in playground folder

### DIFF
--- a/questions/00015-medium-last/info.yml
+++ b/questions/00015-medium-last/info.yml
@@ -8,3 +8,5 @@ author:
 tags: array
 
 related: 14, 16
+
+difficulty: medium

--- a/questions/00016-medium-pop/info.yml
+++ b/questions/00016-medium-pop/info.yml
@@ -8,3 +8,5 @@ author:
 tags: array
 
 related: 14, 15
+
+difficulty: medium

--- a/questions/00017-hard-currying-1/info.yml
+++ b/questions/00017-hard-currying-1/info.yml
@@ -8,3 +8,5 @@ author:
 tags: array
 
 related: 14, 16, 462
+
+difficulty: hard

--- a/questions/00018-easy-tuple-length/info.yml
+++ b/questions/00018-easy-tuple-length/info.yml
@@ -6,3 +6,5 @@ author:
   github: sinoon
 
 tags: tuple
+
+difficulty: easy


### PR DESCRIPTION
Fixes https://github.com/type-challenges/type-challenges/issues/25615

This is happening because there is no `difficulty` in the `info.yml` file for questions 00015, 00016, 00017 and 00018.