### PR TITLE
Add new test case for challenge 00015-medium-last

### DIFF
--- a/questions/00015-medium-last/test-cases.ts
+++ b/questions/00015-medium-last/test-cases.ts
@@ -1,6 +1,7 @@
 import type { Equal, Expect } from '@type-challenges/utils'
 
 type cases = [
+  Expect<Equal<Last<[2]>, 2>>,
   Expect<Equal<Last<[3, 2, 1]>, 1>>,
   Expect<Equal<Last<[() => 123, { a: string }]>, { a: string }>>,
 ]


### PR DESCRIPTION
At the moment it is possible to write a naive backwards solution that covers both existing test cases, but overall would be flawed.

```ts
type Last<T extends any[]> = T extends [infer _Head, ...infer Tail]
  ? Tail['length'] extends 1
    ? Tail[0]
    : Last<Tail>
  : never

...

// Both cases pass
type cases = [
  Expect<Equal<Last<[3, 2, 1]>, 1>>,
  Expect<Equal<Last<[() => 123, { a: string }]>, { a: string }>>,
]
```

This PR adds a case where the array contains only a single element.