### PR TITLE
533 - add more test cases

### DIFF
--- a/questions/00533-easy-concat/test-cases.ts
+++ b/questions/00533-easy-concat/test-cases.ts
@@ -1,8 +1,14 @@
 import type { Equal, Expect } from '@type-challenges/utils'
 
+const tuple = [1] as const
+
 type cases = [
   Expect<Equal<Concat<[], []>, []>>,
   Expect<Equal<Concat<[], [1]>, [1]>>,
+  Expect<Equal<Concat<typeof tuple, typeof tuple>, [1, 1]>>,
   Expect<Equal<Concat<[1, 2], [3, 4]>, [1, 2, 3, 4]>>,
   Expect<Equal<Concat<['1', 2, '3'], [false, boolean, '4']>, ['1', 2, '3', false, boolean, '4']>>,
 ]
+
+// @ts-expect-error
+type error = Concat<null, undefined>


### PR DESCRIPTION
The test case didn't provide a negative path, but it's better to have one.

I also added one test case to check if the solution can take in readonly tuples.