### PR TITLE
feat: generate-play can structurize playground and preserve changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.log
 *.local
 playground/
+.playgroundcache

--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ pnpm generate
 
 It will prompt you to select the desired language, then you can find the generated challenges in the `./playground` folder.
 
+Later if you want to update playground while keeping your changes:
+
+```bash
+pnpm generate --keep-changes
+```
+OR
+```bash
+pnpm generate -K
+```
+
 ## Thanks
 
 This project was born from solving real-world types problem with [@hardfist](https://github.com/hardfist) and [@MeCKodo](https://github.com/MeCKodo). And great thanks to [@sinoon](https://github.com/sinoon) who contributed a lot while giving early feedback on this project.


### PR DESCRIPTION
Fixes: https://github.com/type-challenges/type-challenges/issues/27365
Fixes: https://github.com/type-challenges/type-challenges/issues/27420

This PR will allow `generate-play` script to do these things
1. `pnpm generate -K` will not override files that users have edited
2. both `pnpm generate` and `pnpm generate -K` will generate a structured playground, categorized by difficulty
```
playground
├── warm
├── easy
├── medium
├── hard
└── extreme
```