### PR TITLE
test: add more test cases to 10969-medium-integer

### DIFF
--- a/questions/10969-medium-integer/test-cases.ts
+++ b/questions/10969-medium-integer/test-cases.ts
@@ -9,6 +9,9 @@ type cases1 = [
   Expect<Equal<Integer<1.1>, never>>,
   Expect<Equal<Integer<1.0>, 1>>,
   Expect<Equal<Integer<1.000000000>, 1>>,
+  Expect<Equal<Integer<0.5>, never>>,
+  Expect<Equal<Integer<28.00>, 28>>,
+  Expect<Equal<Integer<28.101>, never>>,
   Expect<Equal<Integer<typeof x>, never>>,
   Expect<Equal<Integer<typeof y>, 1>>,
 ]


### PR DESCRIPTION
These test cases can play a part when players parse the number bit by bit