### PR TITLE
test: add essential test cases to 4037-IsPalindrome

### DIFF
--- a/questions/04037-hard-ispalindrome/test-cases.ts
+++ b/questions/04037-hard-ispalindrome/test-cases.ts
@@ -4,7 +4,9 @@ type cases = [
   Expect<Equal<IsPalindrome<'abc'>, false>>,
   Expect<Equal<IsPalindrome<'b'>, true>>,
   Expect<Equal<IsPalindrome<'abca'>, false>>,
+  Expect<Equal<IsPalindrome<'abba'>, true>>,
   Expect<Equal<IsPalindrome<'abcba'>, true>>,
   Expect<Equal<IsPalindrome<121>, true>>,
+  Expect<Equal<IsPalindrome<2332>, true>>,
   Expect<Equal<IsPalindrome<19260817>, false>>,
 ]


### PR DESCRIPTION
There are 2 types of palindrome, odd one, which has been already covered, and even one, which is added by this PR.