### PR TITLE
1978 - Percentage Parser add test cases

### DIFF
--- a/questions/01978-medium-percentage-parser/test-cases.ts
+++ b/questions/01978-medium-percentage-parser/test-cases.ts
@@ -12,6 +12,9 @@ type Case8 = ['-', '1', '']
 type Case9 = ['', '', '%']
 type Case10 = ['', '1', '']
 type Case11 = ['', '100', '']
+type Case12 = ['+', '', '%']
+type Case13 = ['', '', '%']
+type Case14 = ['+', '', '']
 
 type cases = [
   Expect<Equal<PercentageParser<''>, Case0>>,
@@ -26,4 +29,7 @@ type cases = [
   Expect<Equal<PercentageParser<'%'>, Case9>>,
   Expect<Equal<PercentageParser<'1'>, Case10>>,
   Expect<Equal<PercentageParser<'100'>, Case11>>,
+  Expect<Equal<PercentageParser<'+ABC%'>, Case12>>,
+  Expect<Equal<PercentageParser<'ABC%'>, Case13>>,
+  Expect<Equal<PercentageParser<'+ABC'>, Case14>>,
 ]


### PR DESCRIPTION
According to the description of the topic:

> The structure should be: [plus or minus, number, unit] If it is not captured, the default is an empty string.

I think non-numeric test cases should be added.
There are almost no answers for this case in the current answers


