### PR TITLE
test(11-easy-tuple-to-object): add symbol for test cases

### DIFF
--- a/questions/00011-easy-tuple-to-object/test-cases.ts
+++ b/questions/00011-easy-tuple-to-object/test-cases.ts
@@ -2,12 +2,16 @@ import type { Equal, Expect } from '@type-challenges/utils'
 
 const tuple = ['tesla', 'model 3', 'model X', 'model Y'] as const
 const tupleNumber = [1, 2, 3, 4] as const
-const tupleMix = [1, '2', 3, '4'] as const
+const sym1 = Symbol(1)
+const sym2 = Symbol(2)
+const tupleSymbol = [sym1, sym2] as const
+const tupleMix = [1, '2', 3, '4', sym1] as const
 
 type cases = [
   Expect<Equal<TupleToObject<typeof tuple>, { tesla: 'tesla'; 'model 3': 'model 3'; 'model X': 'model X'; 'model Y': 'model Y' }>>,
   Expect<Equal<TupleToObject<typeof tupleNumber>, { 1: 1; 2: 2; 3: 3; 4: 4 }>>,
-  Expect<Equal<TupleToObject<typeof tupleMix>, { 1: 1; '2': '2'; 3: 3; '4': '4' }>>,
+  Expect<Equal<TupleToObject<typeof tupleSymbol>, { [sym1]: typeof sym1; [sym2]: typeof sym2 }>>,
+  Expect<Equal<TupleToObject<typeof tupleMix>, { 1: 1; '2': '2'; 3: 3; '4': '4'; [sym1]: typeof sym1 }>>,
 ]
 
 // @ts-expect-error


### PR DESCRIPTION
I think it'll be better and more comprehensive if we add symbol for test cases