### PR TITLE
chore: upgrade esno

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "utils:release": "pnpm -C utils release"
   },
   "dependencies": {
-    "esno": "^0.16.3",
+    "esno": "^4.0.0",
     "fast-glob": "^3.2.11",
     "fs-extra": "^10.1.0",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
I don't know why but esno 0.16.3 does not accept "import" statement.
Tweaking tsconfig, like setting "module" to "esnext", did not help.  
Upgrading to esno v4 resolved this issue in my env, MacOS 14.2, Node v20.5.1, vscode 1.85.1.