### PR TITLE
chore: typo questions/00612-medium-kebabcase/README.ja.md

### DIFF
--- a/questions/00612-medium-kebabcase/README.ja.md
+++ b/questions/00612-medium-kebabcase/README.ja.md
@@ -1,6 +1,6 @@
 <!--info-header-start--><h1>KebabCase <img src="https://img.shields.io/badge/-%E4%B8%AD%E7%B4%9A-d9901a" alt="中級"/> <img src="https://img.shields.io/badge/-%23template--literal-999" alt="#template-literal"/></h1><blockquote><p>by Johnson Chu <a href="https://github.com/johnsoncodehk" target="_blank">@johnsoncodehk</a></p></blockquote><p><a href="https://tsch.js.org/612/play/ja" target="_blank"><img src="https://img.shields.io/badge/-%E6%8C%91%E6%88%A6%E3%81%99%E3%82%8B-3178c6?logo=typescript&logoColor=white" alt="挑戦する"/></a> &nbsp;&nbsp;&nbsp;<a href="./README.md" target="_blank"><img src="https://img.shields.io/badge/-English-gray" alt="English"/></a>  <a href="./README.ko.md" target="_blank"><img src="https://img.shields.io/badge/-%ED%95%9C%EA%B5%AD%EC%96%B4-gray" alt="한국어"/></a> </p><!--info-header-end-->
 
-キャメルケースもしくはパスカルケースの文字列を、ケバブケースに置換する方を実装します。
+キャメルケースもしくはパスカルケースの文字列を、ケバブケースに置換する型を実装します。
 
 `FooBarBaz` -> `foo-bar-baz`
 


### PR DESCRIPTION
In Japanese, we found an error in the description of homonyms in kanji, which has been corrected.