### PR TITLE
Expand test cases for `30301-IsOdd`

### DIFF
--- a/questions/30301-medium-isodd/test-cases.ts
+++ b/questions/30301-medium-isodd/test-cases.ts
@@ -1,8 +1,11 @@
 import type { Equal, Expect } from '@type-challenges/utils'
 
 type cases = [
+  Expect<Equal<IsOdd<5>, true>>,
   Expect<Equal<IsOdd<2023>, true>>,
   Expect<Equal<IsOdd<1453>, true>>,
   Expect<Equal<IsOdd<1926>, false>>,
+  Expect<Equal<IsOdd<2.3>, false>>,
+  Expect<Equal<IsOdd<3e23>, false>>,
   Expect<Equal<IsOdd<number>, false>>,
 ]


### PR DESCRIPTION
The new test cases cover some interesting failure modes, such as false negatives for single-digit numbers, and false positives for fractional numbers and scientific-notation.