### PR TITLE
21220: Update multi-line comment to single-line comments

### DIFF
--- a/questions/21220-medium-permutations-of-tuple/README.md
+++ b/questions/21220-medium-permutations-of-tuple/README.md
@@ -6,15 +6,13 @@ For example:
 
 ```ts
 PermutationsOfTuple<[1, number, unknown]>
-/**
- * Should return:
- * | [1, number, unknown]
- * | [1, unknown, number]
- * | [number, 1, unknown]
- * | [unknown, 1, number]
- * | [number, unknown, 1]
- * | [unknown, number ,1]
- */ 
+// Should return:
+// | [1, number, unknown]
+// | [1, unknown, number]
+// | [number, 1, unknown]
+// | [unknown, 1, number]
+// | [number, unknown, 1]
+// | [unknown, number ,1]
 ```
 
 


### PR DESCRIPTION
The README.md for the challenge [21220](https://github.com/type-challenges/type-challenges/tree/main/questions/21220-medium-permutations-of-tuple) includes a multi-line comment, which causes the associated [playground](https://tsch.js.org/21220/play) to break. This PR fixes the issue by replacing the multi-line comment with multiple single-line comments.

<img width="1512" alt="Screenshot 2024-04-21 at 16 58 33" src="https://github.com/type-challenges/type-challenges/assets/7889778/6c34c041-7488-4586-b36d-ee346e9ba2c0">