### PR TITLE
test: add a test case to 00003-medium-omit

### DIFF
--- a/questions/00003-medium-omit/test-cases.ts
+++ b/questions/00003-medium-omit/test-cases.ts
@@ -3,6 +3,7 @@ import type { Equal, Expect } from '@type-challenges/utils'
 type cases = [
   Expect<Equal<Expected1, MyOmit<Todo, 'description'>>>,
   Expect<Equal<Expected2, MyOmit<Todo, 'description' | 'completed'>>>,
+  Expect<Equal<Expected3, MyOmit<Todo1, 'description' | 'completed'>>>,
 ]
 
 // @ts-expect-error
@@ -14,6 +15,12 @@ interface Todo {
   completed: boolean
 }
 
+interface Todo1 {
+  readonly title: string
+  description: string
+  completed: boolean
+}
+
 interface Expected1 {
   title: string
   completed: boolean
@@ -21,4 +28,8 @@ interface Expected1 {
 
 interface Expected2 {
   title: string
+}
+
+interface Expected3 {
+  readonly title: string
 }


### PR DESCRIPTION
I think should add a new test case to the 00003-medium-omit test file.

```typescript
Expect<Equal<Expected3, MyOmit<Todo1, 'description' | 'completed'>>>

interface Todo1 {
  readonly title: string
  description: string
  completed: boolean
}

interface Expected3 {
  readonly title: string
}
```
The previous test cases do not cover the scenario where the MyOmit generic might cause loss of modifiers for non-omitted properties. 
For example, the following generic can pass the previous test cases.However, it can cause the loss of modifiers for non-omitted properties.

```typescript
export type MyOmit<T, K extends keyof T> = {
    [P in myExclude<keyof T, K>]: T[P]
}
type myExclude<T, K> = T extends K ? never : T;
````
Then, I found that TypeScript's Omit<T, K> generic does not cause the loss of modifiers for non-omitted properties.




