### PR TITLE
test: Add test case for `boolean` in 268-If 

### DIFF
--- a/questions/00268-easy-if/test-cases.ts
+++ b/questions/00268-easy-if/test-cases.ts
@@ -3,6 +3,7 @@ import type { Equal, Expect } from '@type-challenges/utils'
 type cases = [
   Expect<Equal<If<true, 'a', 'b'>, 'a'>>,
   Expect<Equal<If<false, 'a', 2>, 2>>,
+  Expect<Equal<If<boolean, 'a', 2>, 'a' | 2>>,
 ]
 
 // @ts-expect-error


### PR DESCRIPTION
I've added the test case that covers a union of `true | false` (also known as a `boolean`):
```typescript
Expect<Equal<If<boolean, 'a', 2>, 'a' | 2>>
```

Without this test case, the following (incorrect) solution is accepted:
```typescript
type If<C extends boolean, T, F> = true extends C ? T : F;

// X is 'a'
type X = If<boolean, 'a', 2>
```
Flipping the `extends` condition (as done in the most popular solution: https://github.com/type-challenges/type-challenges/issues/279) behaves as expected:
```typescript
type If<C extends boolean, T, F> = C extends true  ? T : F;

// X is 'a' | 2
type X = If<boolean, 'a', 2>
```