### PR TITLE
test: remove unnecessary test-case from 00189-easy-awaited

### DIFF
--- a/questions/00189-easy-awaited/test-cases.ts
+++ b/questions/00189-easy-awaited/test-cases.ts
@@ -14,5 +14,3 @@ type cases = [
   Expect<Equal<MyAwaited<T>, number>>,
 ]
 
-// @ts-expect-error
-type error = MyAwaited<number>


### PR DESCRIPTION
## 00189 Easy Awaited - Remove test case
My proposal is to remove the test case that expects an error when providing `number` as argument. 

The original `Awaited<T>` also accepts primitive types, does not throw an error and simply returns the primitive. You can find the type in the [original TypeScript Repository](https://github.com/microsoft/TypeScript/blob/af3a61fe4487a92d59f9479aa4249d897b91af14/src/lib/es5.d.ts#L1545).

A solution to the challenge without this test: 

```ts
type MyAwaited<T> = 
T extends PromiseLike<infer Val> 
    ? MyAwaited<Val> 
    : T
```

Compare that to a solution that goes the extra length to make the test pass:
```ts
type MyAwaited<T extends PromiseLike<any>> = 
T extends PromiseLike<infer Val> 
  ? Val extends PromiseLike<unknown>
    ? MyAwaited<Val> 
    : Val
  : never
```

I'm not removing this test to make the solution easier. My goal is to make the solution more reliable and act more like the original `Awaited<T>` generic.