### PR TITLE
feat: add test case for '-.3' in 05140-Trunc

### DIFF
--- a/questions/05140-medium-trunc/test-cases.ts
+++ b/questions/05140-medium-trunc/test-cases.ts
@@ -8,6 +8,7 @@ type cases = [
   Expect<Equal<Trunc<-5.1>, '-5'>>,
   Expect<Equal<Trunc<'.3'>, '0'>>,
   Expect<Equal<Trunc<'1.234'>, '1'>>,
+  Expect<Equal<Trunc<'-.3'>, '-0'>>,
   Expect<Equal<Trunc<'-10.234'>, '-10'>>,
   Expect<Equal<Trunc<10>, '10'>>,
 ]


### PR DESCRIPTION
The case Math.trunc('-.3') is valid but is not covered on Trunc tests cases.
Having a test for Trunc<'-.3'> will force to add another check in the implementation to cover that specific case. Not more difficult but just a little twist.
