### PR TITLE
test: add test case to 25270-medium-transpose

### DIFF
--- a/questions/25270-medium-transpose/test-cases.ts
+++ b/questions/25270-medium-transpose/test-cases.ts
@@ -8,4 +8,6 @@ type cases = [
   Expect<Equal<Transpose<[[1, 2, 3], [4, 5, 6]]>, [[1, 4], [2, 5], [3, 6]]>>,
   Expect<Equal<Transpose<[[1, 4], [2, 5], [3, 6]]>, [[1, 2, 3], [4, 5, 6]]>>,
   Expect<Equal<Transpose<[[1, 2, 3], [4, 5, 6], [7, 8, 9]]>, [[1, 4, 7], [2, 5, 8], [3, 6, 9]]>>,
+  Expect<Equal<Transpose<[[1, 2, 3], [4, 5]]>, [[1, 4], [2, 5], [3, never]]>>,
+  Expect<Equal<Transpose<[[1, 2], [3, 4, 5, 6]]>, [[1, 3], [2, 4], [never, 5], [never, 6]]>>,
 ]


### PR DESCRIPTION
Considering that the lengths of the matrix arrays may not be the same, the case below is valid for transpose matrix but is not covered on tests cases.
`Expect<Equal<Transpose<[[1, 2, 3], [4, 5]]>, [[1, 4], [2, 5], [3, never]]>>`