### PR TITLE
test(27133-medium-square): add test cases

### DIFF
--- a/questions/27133-medium-square/test-cases.ts
+++ b/questions/27133-medium-square/test-cases.ts
@@ -6,6 +6,7 @@ type cases = [
   Expect<Equal<Square<3>, 9>>,
   Expect<Equal<Square<20>, 400>>,
   Expect<Equal<Square<100>, 10000>>,
+  Expect<Equal<Square<101>, 10201>>,
 
   // Negative numbers
   Expect<Equal<Square<-2>, 4>>,


### PR DESCRIPTION
I noticed that some solutions treat `100` as a special case. I think it shouldn’t be treated as such, so I added a test case with `101` .