### PR TITLE
fix: fix length of string 3 tests

### DIFF
--- a/questions/31824-hard-length-of-string-3/test-cases.ts
+++ b/questions/31824-hard-length-of-string-3/test-cases.ts
@@ -18,15 +18,21 @@ type t3 = Reped<t2, 10>
 type t4 = Reped<t3, 10>
 type t5 = Reped<t4, 10>
 type t6 = Reped<t5, 10>
-type Gened<N extends string> = N extends `${''
-  }${infer N6 extends Signum
-  }${infer N5 extends Signum
-  }${infer N4 extends Signum
-  }${infer N3 extends Signum
-  }${infer N2 extends Signum
-  }${infer N1 extends Signum
-  }${infer N0 extends Signum
-  }` ? `${''
+type Signums<
+  N extends string,
+  Acc extends readonly Signum[] = [],
+> = N extends `${infer Head extends Signum}${infer Rest}`
+  ? Signums<Rest, [...Acc, Head]>
+  : Acc
+type Gened<N extends string> = Signums<N> extends [
+  infer N6 extends Signum,
+  infer N5 extends Signum,
+  infer N4 extends Signum,
+  infer N3 extends Signum,
+  infer N2 extends Signum,
+  infer N1 extends Signum,
+  infer N0 extends Signum,
+] ? `${''
   }${Reped<t6, N6>
   }${Reped<t5, N5>
   }${Reped<t4, N4>


### PR DESCRIPTION
The `Gened` type in the "Length of String 3" test cases produces the following error:

![image](https://github.com/user-attachments/assets/9ddbfae9-a2c6-40ed-af91-afdd12d6e06f)

This PR fixes it by inferring the digits from the input recursively instead of doing it all at once.