### PR TITLE
case(#02257):remove zero case

### DIFF
--- a/questions/02257-medium-minusone/test-cases.ts
+++ b/questions/02257-medium-minusone/test-cases.ts
@@ -6,6 +6,5 @@ type cases = [
   Expect<Equal<MinusOne<3>, 2>>,
   Expect<Equal<MinusOne<100>, 99>>,
   Expect<Equal<MinusOne<1101>, 1100>>,
-  Expect<Equal<MinusOne<0>, -1>>,
   Expect<Equal<MinusOne<9_007_199_254_740_992>, 9_007_199_254_740_991>>,
 ]


### PR DESCRIPTION
in this challenge (#02257).
the describe is
> Given a number (always positive) as a type. Your type should return the number decreased by one.

so it should be a number more then zero.
but in cases `Equal<MinusOne<0>, -1>` happened .

i think should remove it.
