### PR TITLE
case(IsOdd): add 3e0 case

### DIFF
--- a/questions/30301-medium-isodd/test-cases.ts
+++ b/questions/30301-medium-isodd/test-cases.ts
@@ -7,5 +7,6 @@ type cases = [
   Expect<Equal<IsOdd<1926>, false>>,
   Expect<Equal<IsOdd<2.3>, false>>,
   Expect<Equal<IsOdd<3e23>, false>>,
+  Expect<Equal<IsOdd<3e0>, true>>,
   Expect<Equal<IsOdd<number>, false>>,
 ]


### PR DESCRIPTION
add Test Case to [IsOdd](https://github.com/type-challenges/type-challenges/blob/main/questions/30301-medium-isodd/README.md)

There is already a test case for `3e23`, which is always even because it represents 3×10^23.
However, in the case of `3e0`, it equals 3×10^0=3×1=3, which is odd.

In other words, when the exponent is 0, we need to check the number before `e` to determine whether it is odd or even.