### PR TITLE
[30301 Medium IsOdd] Add Test Cases for Exponentials

### DIFF
--- a/questions/30301-medium-isodd/test-cases.ts
+++ b/questions/30301-medium-isodd/test-cases.ts
@@ -8,5 +8,11 @@ type cases = [
   Expect<Equal<IsOdd<2.3>, false>>,
   Expect<Equal<IsOdd<3e23>, false>>,
   Expect<Equal<IsOdd<3e0>, true>>,
+  Expect<Equal<IsOdd<1.1e1>, true>>,
+  Expect<Equal<IsOdd<1.01e2>, true>>,
+  Expect<Equal<IsOdd<1.2e1>, false>>,
+  Expect<Equal<IsOdd<1.02e2>, false>>,
+  Expect<Equal<IsOdd<100e-2>, false>>,
+  Expect<Equal<IsOdd<320e-1>, false>>,
   Expect<Equal<IsOdd<number>, false>>,
 ]


### PR DESCRIPTION
Some exponential literals denote integers, such as `1.1e1`, `1.02e2`, `100e2`, etc., even if where the exponent parts are not zero.