### PR TITLE
case(Integers Comparator): add consider decimal

### DIFF
--- a/questions/00274-extreme-integers-comparator/test-cases.ts
+++ b/questions/00274-extreme-integers-comparator/test-cases.ts
@@ -33,4 +33,8 @@ type cases = [
   Expect<Equal<Comparator<9007199254740992, 9007199254740991>, Comparison.Greater>>,
   Expect<Equal<Comparator<-9007199254740992, -9007199254740991>, Comparison.Lower>>,
   Expect<Equal<Comparator<-9007199254740991, -9007199254740992>, Comparison.Greater>>,
+  Expect<Equal<Comparator<3.1415, 3.1415>, Comparison.Equal>>,
+  Expect<Equal<Comparator<3.1415, 3.1414>, Comparison.Greater>>,
+  Expect<Equal<Comparator<0, 3.1414>, Comparison.Lower>>,
+  Expect<Equal<Comparator<31.415, 3.1415>, Comparison.Greater>>,
 ]


### PR DESCRIPTION
Added a pattern for comparing decimals. 

The policy for solving is that you can compare decimals by breaking them down before and after the decimal point. If there is a decimal point, you can look at the decimal point by recursing the Comparator only when the numbers before the decimal point are the same.