### PR TITLE
feat: replace picocolors with ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "@types/lz-string": "^1.5.0",
     "@types/node": "^20.10.5",
     "@types/prompts": "^2.4.9",
+    "ansis": "^3.12.0",
     "eslint": "^8.56.0",
-    "picocolors": "^1.0.0",
     "prompts": "^2.4.2",
     "typescript": "^5.3.3",
     "utility-types": "^3.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,12 +45,12 @@ importers:
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
+      ansis:
+        specifier: ^3.12.0
+        version: 3.12.0
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
-      picocolors:
-        specifier: ^1.0.0
-        version: 1.0.0
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -1181,6 +1181,11 @@ packages:
     dependencies:
       '@types/color-name': 1.1.1
       color-convert: 2.0.1
+    dev: true
+
+  /ansis@3.12.0:
+    resolution: {integrity: sha512-SxhlInpMkv9QCyI2yHyrhVrTF8dH93M/S86DT5f9brFgr92uJLOCg0RNmtx3YKWKcRmNAaU+gyUfHMdUiqxvFw==}
+    engines: {node: '>=14'}
     dev: true
 
   /are-docs-informative@0.0.2:

--- a/scripts/generate-play.ts
+++ b/scripts/generate-play.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import process from 'node:process'
 import crypto from 'node:crypto'
 import fs from 'fs-extra'
-import c from 'picocolors'
+import c from 'ansis'
 import prompts from 'prompts'
 import { formatToCode } from './actions/utils/formatToCode'
 import { loadQuizes, resolveInfo } from './loader'
@@ -96,7 +96,7 @@ async function generatePlayground() {
 
   let locale = supportedLocales.find(locale => locale === process.argv[2])!
 
-  console.log(c.bold(c.cyan('Generating local playground...\n')))
+  console.log(c.bold.cyan('Generating local playground...\n'))
 
   let overridableFiles: Snapshot
   let keepChanges = false
@@ -104,7 +104,7 @@ async function generatePlayground() {
   let playgroundSnapshot: Snapshot
 
   if (process.argv.length === 3 && (process.argv[2] === '--keep-changes' || process.argv[2] === '-K')) {
-    console.log(c.bold(c.cyan('We will keep your changes while generating.\n')))
+    console.log(c.bold.cyan('We will keep your changes while generating.\n'))
     keepChanges = true
 
     playgroundSnapshot = await takeSnapshot(playgroundPath)
@@ -150,7 +150,7 @@ async function generatePlayground() {
     const code = formatToCode(quiz, locale)
 
     if (difficulty === undefined || title === undefined) {
-      console.log(c.yellow(`${quiz.no} has no ${locale.toUpperCase()} version. Skipping`))
+      console.log(c.yellow`${quiz.no} has no ${locale.toUpperCase()} version. Skipping`)
       continue
     }
 
@@ -173,7 +173,7 @@ async function generatePlayground() {
   }))
 
   console.log()
-  console.log(c.bold(c.green('Local playground generated at: ')) + c.dim(playgroundPath))
+  console.log(c.bold.green('Local playground generated at: ') + c.dim(playgroundPath))
   console.log()
 }
 


### PR DESCRIPTION
Hello @antfu,

This PR replaces `picocolors` with a better alternative `ansis` that supports both CJS and ESM.
Ansis supports chained syntax for clean and readable code.