### PR TITLE
add a test-case with different type in PromiseAll generic

### DIFF
--- a/questions/00020-medium-promise-all/test-cases.ts
+++ b/questions/00020-medium-promise-all/test-cases.ts
@@ -4,10 +4,12 @@ const promiseAllTest1 = PromiseAll([1, 2, 3] as const)
 const promiseAllTest2 = PromiseAll([1, 2, Promise.resolve(3)] as const)
 const promiseAllTest3 = PromiseAll([1, 2, Promise.resolve(3)])
 const promiseAllTest4 = PromiseAll<Array<number | Promise<number>>>([1, 2, 3])
+const promiseAllTest5 = PromiseAll<(number | Promise<string>)[]>([1, 2, Promise.resolve('3')])
 
 type cases = [
   Expect<Equal<typeof promiseAllTest1, Promise<[1, 2, 3]>>>,
   Expect<Equal<typeof promiseAllTest2, Promise<[1, 2, number]>>>,
   Expect<Equal<typeof promiseAllTest3, Promise<[number, number, number]>>>,
   Expect<Equal<typeof promiseAllTest4, Promise<number[]>>>,
+  Expect<Equal<typeof promiseAllTest5, Promise<(number | string)[]>>>,
 ]


### PR DESCRIPTION
`const promiseAllTest6 = PromiseAll<Array<number | Promise<string>>>([1, 2, Promise.resolve("3")]);`