### PR TITLE
fix: correct tag to `template-literal`

### DIFF
--- a/questions/25747-hard-isnegativenumber/info.yml
+++ b/questions/25747-hard-isnegativenumber/info.yml
@@ -1,6 +1,6 @@
 difficulty: hard
 title: IsNegativeNumber
-tags: number, template literal
+tags: number, template-literal
 author:
   github: ahrjarrett
   name: andrew jarrett


### PR DESCRIPTION
This PR replaces `template literal` with `template-literal` for consistency and will fix the duplicate tag generation issue.

<img src="https://github.com/user-attachments/assets/3db113c7-8330-4809-bd4c-a47235c4b46c" width="400">