### PR TITLE
Add test case to 18142-medium-all

### DIFF
--- a/questions/18142-medium-all/test-cases.ts
+++ b/questions/18142-medium-all/test-cases.ts
@@ -16,4 +16,5 @@ type cases = [
   Expect<Equal<All<[any], unknown>, false>>,
   Expect<Equal<All<[unknown], any>, false>>,
   Expect<Equal<All<[1, 1, 2], 1 | 2>, false>>,
+  Expect<Equal<All<[], 1>, false>>,
 ]


### PR DESCRIPTION
Add test case for a empty array: Expect<Equal<All<[], 1>, false>>