### PR TITLE
docs: add solution link to typescriptpro.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You can also use some existing type utility libraries such as [type-fest](https:
 - [Type Challenges Solutions](https://github.com/ghaiklor/type-challenges-solutions)
 - [Type Gymnastics](https://github.com/g-plane/type-gymnastics)
 - [TypeType Examples](https://github.com/mistlog/typetype-examples)
+- [TypeScriptPro Solutions](https://typescriptpro.com/challenges)
 
 ### Books
 


### PR DESCRIPTION
Follow-up to #37293 

@antfu If it's fine for you I would also add the following (in a follow-up PR) - otherwise I'll leave it to this.

## Add link with text in the following section 

> ⚡️ Start the challenge on [TypeScriptPro](https://typescriptpro.com/challenges)

<img width="755" height="181" alt="image" src="https://github.com/user-attachments/assets/21d1f92f-be2e-4b82-a6da-1104d98acde3" />
