### PR TITLE
Fix Typescript unused value error on question 03312-easy-parameters

### DIFF
--- a/questions/03312-easy-parameters/test-cases.ts
+++ b/questions/03312-easy-parameters/test-cases.ts
@@ -1,7 +1,7 @@
 import type { Equal, Expect } from '@type-challenges/utils'
 
-function foo(arg1: string, arg2: number): void {}
-function bar(arg1: boolean, arg2: { a: 'A' }): void {}
+function foo(_arg1: string, _arg2: number): void {}
+function bar(_arg1: boolean, _arg2: { a: 'A' }): void {}
 function baz(): void {}
 
 type cases = [


### PR DESCRIPTION
### TypeScript is throwing a "value declared but never used" error for the unused parameters in the test cases for question (03312-easy-parameters), which ends up causing a compilation error on the site despite the answer being correct.

added _ prefix to ignore the unused parameters
 
```typescript 
function foo(_arg1: string, _arg2: number): void {}
function bar(_arg1: boolean, _arg2: { a: 'A' }): void {}
```
#### Error Image of site 

<img width="1913" height="927" alt="image" src="https://github.com/user-attachments/assets/51c7e7ca-176b-4dc4-9935-1665581c50a5" />
