### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/index-update.yaml
+++ b/.github/workflows/index-update.yaml
@@ -9,9 +9,9 @@ jobs:
   start:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 16.x
           cache: pnpm

--- a/.github/workflows/issue-pr.yaml
+++ b/.github/workflows/issue-pr.yaml
@@ -8,8 +8,8 @@ jobs:
   start:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 16.x
       - run: cd scripts && npm i --only=production

--- a/.github/workflows/labeling.yaml
+++ b/.github/workflows/labeling.yaml
@@ -8,8 +8,8 @@ jobs:
   start:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 16.x
       - run: cd scripts && npm i --only=production

--- a/.github/workflows/toggle-pr-with-issue.yaml
+++ b/.github/workflows/toggle-pr-with-issue.yaml
@@ -8,8 +8,8 @@ jobs:
   start:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 16.x
       - run: cd scripts && npm i --only=production


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/index-update.yaml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/index-update.yaml`
- Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/toggle-pr-with-issue.yaml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/issue-pr.yaml`
- Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/issue-pr.yaml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/toggle-pr-with-issue.yaml`
- Updated `pnpm/action-setup` from `v2` to `v4` in `.github/workflows/index-update.yaml`
- Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/labeling.yaml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/labeling.yaml`
