### PR TITLE
fix: remove incorrect @ts-expect-error from Omit (00003) test cases

### DIFF
--- a/questions/00003-medium-omit/test-cases.ts
+++ b/questions/00003-medium-omit/test-cases.ts
@@ -6,9 +6,6 @@ type cases = [
   Expect<Equal<Expected3, MyOmit<Todo1, 'description' | 'completed'>>>,
 ]
 
-// @ts-expect-error
-type error = MyOmit<Todo, 'description' | 'invalid'>
-
 interface Todo {
   title: string
   description: string


### PR DESCRIPTION
## Summary

Removes the `@ts-expect-error` test case from the Omit challenge (00003-medium-omit) that incorrectly expected an error when passing keys not present in `T`.

## Problem

The test cases included:

```ts
// @ts-expect-error
type error = MyOmit<Todo, 'description' | 'invalid'>
```

This expected solutions to error when `K` contains keys not in `keyof T`. However, TypeScript's built-in `Omit<T, K>` is defined as:

```ts
type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
```

Note `K extends keyof any` (i.e., `K extends PropertyKey`), **not** `K extends keyof T`. Passing keys that don't exist in `T` is perfectly valid — they're simply ignored by `Exclude`. This means the test case was requiring implementations to be **more restrictive** than the built-in they're supposed to replicate.

## Changes

- Removed the `@ts-expect-error` line and the `error` type alias from `test-cases.ts`

Fixes #36978
Also addresses #34404 and #34285

🤖 Generated with [Claude Code](https://claude.com/claude-code)