### PR TITLE
Add read-only check to the "Pick" test cases

### DIFF
--- a/questions/00004-easy-pick/test-cases.ts
+++ b/questions/00004-easy-pick/test-cases.ts
@@ -3,12 +3,19 @@ import type { Equal, Expect } from '@type-challenges/utils'
 type cases = [
   Expect<Equal<Expected1, MyPick<Todo, 'title'>>>,
   Expect<Equal<Expected2, MyPick<Todo, 'title' | 'completed'>>>,
+  Expect<Equal<Expected3, MyPick<TodoReadOnly, 'title'>>>,
   // @ts-expect-error
   MyPick<Todo, 'title' | 'completed' | 'invalid'>,
 ]
 
 interface Todo {
   title: string
+  description: string
+  completed: boolean
+}
+
+interface TodoReadOnly {
+  readonly title: string
   description: string
   completed: boolean
 }
@@ -20,4 +27,8 @@ interface Expected1 {
 interface Expected2 {
   title: string
   completed: boolean
+}
+
+interface Expected3 {
+  readonly title: string
 }


### PR DESCRIPTION
There is a partial solution, which pass all existed tests. But actually is incorrect due to removing read-only from the fields:
```
type MyPick<T, K> = {
  [Key in keyof T & K]: T[Key]
}
```