### PR TITLE
case(Awaited): add nested thenable case

### DIFF
--- a/questions/00189-easy-awaited/test-cases.ts
+++ b/questions/00189-easy-awaited/test-cases.ts
@@ -5,6 +5,7 @@ type Y = Promise<{ field: number }>
 type Z = Promise<Promise<string | number>>
 type Z1 = Promise<Promise<Promise<string | boolean>>>
 type T = { then: (onfulfilled: (arg: number) => any) => any }
+type T1 = { then: (onfulfilled: (arg: T) => any) => any }
 
 type cases = [
   Expect<Equal<MyAwaited<X>, string>>,
@@ -12,4 +13,5 @@ type cases = [
   Expect<Equal<MyAwaited<Z>, string | number>>,
   Expect<Equal<MyAwaited<Z1>, string | boolean>>,
   Expect<Equal<MyAwaited<T>, number>>,
+  Expect<Equal<MyAwaited<T1>, number>>,
 ]


### PR DESCRIPTION
add Test Case to [Awaited](https://github.com/type-challenges/type-challenges/blob/main/questions/00189-easy-awaited/README.md)

The current cases cover nested Promises (`Z`, `Z1`) and a single-level thenable (`T`), but not a thenable whose resolved value is itself a thenable.

A solution that recurses only on `Promise` instead of `PromiseLike` passes all the existing cases but stops one level early on this one, while the built-in `Awaited` keeps unwrapping it down to `number`. Added `T1` following the existing `T` case:

```ts
type T1 = { then: (onfulfilled: (arg: T) => any) => any }
// ...
Expect<Equal<MyAwaited<T1>, number>>,
```